### PR TITLE
feat: add persisted map state (only one view)

### DIFF
--- a/migrations/1750325281886_map_view.ts
+++ b/migrations/1750325281886_map_view.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable("mapView")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("config", "jsonb", (col) => col.notNull())
+    .addColumn("organisationId", "uuid", (col) => col.notNull())
+    .addColumn("createdAt", "text", (col) =>
+      col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull(),
+    )
+    .addForeignKeyConstraint(
+      "mapViewOrganisationIdFKey",
+      ["organisationId"],
+      "organisation",
+      ["id"],
+      (cb) => cb.onDelete("cascade").onUpdate("cascade"),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable("mapView").execute();
+}

--- a/migrations/1750325535413_data_source_org_foreign_key.ts
+++ b/migrations/1750325535413_data_source_org_foreign_key.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("dataSource")
+    .addForeignKeyConstraint(
+      "dataSourceOrganisationIdFKey",
+      ["organisationId"],
+      "organisation",
+      ["id"],
+    )
+    .onDelete("cascade")
+    .onUpdate("cascade")
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("dataSource")
+    .dropConstraint("dataSourceOrganisationIdFKey")
+    .execute();
+}

--- a/src/__generated__/types.ts
+++ b/src/__generated__/types.ts
@@ -44,6 +44,11 @@ export enum AreaSetCode {
   WMC24 = "WMC24",
 }
 
+export enum AreaSetGroupCode {
+  OA21 = "OA21",
+  WMC24 = "WMC24",
+}
+
 export type AreaStat = {
   __typename?: "AreaStat";
   areaCode: Scalars["String"]["output"];
@@ -209,12 +214,56 @@ export type LooseGeocodingConfigInput = {
   type: GeocodingType;
 };
 
+export type MapConfig = {
+  __typename?: "MapConfig";
+  areaDataColumn: Scalars["String"]["output"];
+  areaDataSourceId: Scalars["String"]["output"];
+  areaSetGroupCode: AreaSetGroupCode;
+  excludeColumnsString: Scalars["String"]["output"];
+  mapStyle: MapStyleName;
+  markersDataSourceId: Scalars["String"]["output"];
+  showBoundaryOutline: Scalars["Boolean"]["output"];
+  showLabels: Scalars["Boolean"]["output"];
+  showLocations: Scalars["Boolean"]["output"];
+  showMembers: Scalars["Boolean"]["output"];
+  showTurf: Scalars["Boolean"]["output"];
+};
+
+export type MapConfigInput = {
+  areaDataColumn?: InputMaybe<Scalars["String"]["input"]>;
+  areaDataSourceId?: InputMaybe<Scalars["String"]["input"]>;
+  areaSetGroupCode?: InputMaybe<AreaSetGroupCode>;
+  excludeColumnsString?: InputMaybe<Scalars["String"]["input"]>;
+  mapStyle?: InputMaybe<MapStyleName>;
+  markersDataSourceId?: InputMaybe<Scalars["String"]["input"]>;
+  showBoundaryOutline?: InputMaybe<Scalars["Boolean"]["input"]>;
+  showLabels?: InputMaybe<Scalars["Boolean"]["input"]>;
+  showLocations?: InputMaybe<Scalars["Boolean"]["input"]>;
+  showMembers?: InputMaybe<Scalars["Boolean"]["input"]>;
+  showTurf?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+export enum MapStyleName {
+  Dark = "Dark",
+  Light = "Light",
+  Satellite = "Satellite",
+  Streets = "Streets",
+}
+
+export type MapView = {
+  __typename?: "MapView";
+  config: MapConfig;
+  id: Scalars["String"]["output"];
+  organisationId: Scalars["String"]["output"];
+};
+
 export type Mutation = {
   __typename?: "Mutation";
   createDataSource?: Maybe<CreateDataSourceResponse>;
   enqueueEnrichDataSourceJob?: Maybe<MutationResponse>;
   enqueueImportDataSourceJob?: Maybe<MutationResponse>;
   updateDataSourceConfig?: Maybe<MutationResponse>;
+  upsertMapView?: Maybe<UpsertMapViewResponse>;
 };
 
 export type MutationCreateDataSourceArgs = {
@@ -240,6 +289,12 @@ export type MutationUpdateDataSourceConfigArgs = {
   looseGeocodingConfig?: InputMaybe<LooseGeocodingConfigInput>;
 };
 
+export type MutationUpsertMapViewArgs = {
+  config: MapConfigInput;
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  organisationId: Scalars["String"]["input"];
+};
+
 export type MutationResponse = {
   __typename?: "MutationResponse";
   code: Scalars["Int"]["output"];
@@ -261,6 +316,7 @@ export type Query = {
   areaStats?: Maybe<AreaStats>;
   dataSource?: Maybe<DataSource>;
   dataSources?: Maybe<Array<DataSource>>;
+  mapViews?: Maybe<Array<MapView>>;
   organisations?: Maybe<Array<Organisation>>;
 };
 
@@ -281,6 +337,10 @@ export type QueryDataSourcesArgs = {
   organisationId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+export type QueryMapViewsArgs = {
+  organisationId: Scalars["String"]["input"];
+};
+
 export type RecordsProcessedEvent = {
   __typename?: "RecordsProcessedEvent";
   at: Scalars["String"]["output"];
@@ -294,6 +354,12 @@ export type Subscription = {
 
 export type SubscriptionDataSourceEventArgs = {
   dataSourceId: Scalars["String"]["input"];
+};
+
+export type UpsertMapViewResponse = {
+  __typename?: "UpsertMapViewResponse";
+  code: Scalars["Int"]["output"];
+  result?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type EnqueueImportDataSourceJobMutationVariables = Exact<{
@@ -519,6 +585,21 @@ export type ListDataSourcesQuery = {
   }> | null;
 };
 
+export type UpsertMapViewMutationVariables = Exact<{
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  config: MapConfigInput;
+  organisationId: Scalars["String"]["input"];
+}>;
+
+export type UpsertMapViewMutation = {
+  __typename?: "Mutation";
+  upsertMapView?: {
+    __typename?: "UpsertMapViewResponse";
+    code: number;
+    result?: string | null;
+  } | null;
+};
+
 export type DataSourcesQueryVariables = Exact<{ [key: string]: never }>;
 
 export type DataSourcesQuery = {
@@ -532,6 +613,32 @@ export type DataSourcesQuery = {
       name: string;
       type: ColumnType;
     }>;
+  }> | null;
+};
+
+export type MapViewsQueryVariables = Exact<{
+  organisationId: Scalars["String"]["input"];
+}>;
+
+export type MapViewsQuery = {
+  __typename?: "Query";
+  mapViews?: Array<{
+    __typename?: "MapView";
+    id: string;
+    config: {
+      __typename?: "MapConfig";
+      areaDataSourceId: string;
+      areaDataColumn: string;
+      areaSetGroupCode: AreaSetGroupCode;
+      excludeColumnsString: string;
+      markersDataSourceId: string;
+      mapStyle: MapStyleName;
+      showBoundaryOutline: boolean;
+      showLabels: boolean;
+      showLocations: boolean;
+      showMembers: boolean;
+      showTurf: boolean;
+    };
   }> | null;
 };
 
@@ -675,6 +782,7 @@ export type DirectiveResolverFn<
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   AreaSetCode: AreaSetCode;
+  AreaSetGroupCode: AreaSetGroupCode;
   AreaStat: ResolverTypeWrapper<AreaStat>;
   AreaStats: ResolverTypeWrapper<AreaStats>;
   ArgNames: ArgNames;
@@ -701,6 +809,10 @@ export type ResolversTypes = {
   LooseEnrichmentInput: LooseEnrichmentInput;
   LooseGeocodingConfig: ResolverTypeWrapper<LooseGeocodingConfig>;
   LooseGeocodingConfigInput: LooseGeocodingConfigInput;
+  MapConfig: ResolverTypeWrapper<MapConfig>;
+  MapConfigInput: MapConfigInput;
+  MapStyleName: MapStyleName;
+  MapView: ResolverTypeWrapper<MapView>;
   Mutation: ResolverTypeWrapper<{}>;
   MutationResponse: ResolverTypeWrapper<MutationResponse>;
   Operation: Operation;
@@ -709,6 +821,7 @@ export type ResolversTypes = {
   RecordsProcessedEvent: ResolverTypeWrapper<RecordsProcessedEvent>;
   String: ResolverTypeWrapper<Scalars["String"]["output"]>;
   Subscription: ResolverTypeWrapper<{}>;
+  UpsertMapViewResponse: ResolverTypeWrapper<UpsertMapViewResponse>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -735,6 +848,9 @@ export type ResolversParentTypes = {
   LooseEnrichmentInput: LooseEnrichmentInput;
   LooseGeocodingConfig: LooseGeocodingConfig;
   LooseGeocodingConfigInput: LooseGeocodingConfigInput;
+  MapConfig: MapConfig;
+  MapConfigInput: MapConfigInput;
+  MapView: MapView;
   Mutation: {};
   MutationResponse: MutationResponse;
   Organisation: Organisation;
@@ -742,6 +858,7 @@ export type ResolversParentTypes = {
   RecordsProcessedEvent: RecordsProcessedEvent;
   String: Scalars["String"]["output"];
   Subscription: {};
+  UpsertMapViewResponse: UpsertMapViewResponse;
 };
 
 export type AuthDirectiveArgs = {
@@ -1002,6 +1119,56 @@ export type LooseGeocodingConfigResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type MapConfigResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends
+    ResolversParentTypes["MapConfig"] = ResolversParentTypes["MapConfig"],
+> = {
+  areaDataColumn?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  areaDataSourceId?: Resolver<
+    ResolversTypes["String"],
+    ParentType,
+    ContextType
+  >;
+  areaSetGroupCode?: Resolver<
+    ResolversTypes["AreaSetGroupCode"],
+    ParentType,
+    ContextType
+  >;
+  excludeColumnsString?: Resolver<
+    ResolversTypes["String"],
+    ParentType,
+    ContextType
+  >;
+  mapStyle?: Resolver<ResolversTypes["MapStyleName"], ParentType, ContextType>;
+  markersDataSourceId?: Resolver<
+    ResolversTypes["String"],
+    ParentType,
+    ContextType
+  >;
+  showBoundaryOutline?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  showLabels?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  showLocations?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  showMembers?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  showTurf?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type MapViewResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends
+    ResolversParentTypes["MapView"] = ResolversParentTypes["MapView"],
+> = {
+  config?: Resolver<ResolversTypes["MapConfig"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  organisationId?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type MutationResolvers<
   ContextType = GraphQLContext,
   ParentType extends
@@ -1033,6 +1200,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationUpdateDataSourceConfigArgs, "id">
+  >;
+  upsertMapView?: Resolver<
+    Maybe<ResolversTypes["UpsertMapViewResponse"]>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpsertMapViewArgs, "config" | "organisationId">
   >;
 };
 
@@ -1081,6 +1254,12 @@ export type QueryResolvers<
     ContextType,
     Partial<QueryDataSourcesArgs>
   >;
+  mapViews?: Resolver<
+    Maybe<Array<ResolversTypes["MapView"]>>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryMapViewsArgs, "organisationId">
+  >;
   organisations?: Resolver<
     Maybe<Array<ResolversTypes["Organisation"]>>,
     ParentType,
@@ -1112,6 +1291,16 @@ export type SubscriptionResolvers<
   >;
 };
 
+export type UpsertMapViewResponseResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends
+    ResolversParentTypes["UpsertMapViewResponse"] = ResolversParentTypes["UpsertMapViewResponse"],
+> = {
+  code?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  result?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type Resolvers<ContextType = GraphQLContext> = {
   AreaStat?: AreaStatResolvers<ContextType>;
   AreaStats?: AreaStatsResolvers<ContextType>;
@@ -1127,12 +1316,15 @@ export type Resolvers<ContextType = GraphQLContext> = {
   JobInfo?: JobInfoResolvers<ContextType>;
   LooseEnrichment?: LooseEnrichmentResolvers<ContextType>;
   LooseGeocodingConfig?: LooseGeocodingConfigResolvers<ContextType>;
+  MapConfig?: MapConfigResolvers<ContextType>;
+  MapView?: MapViewResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   MutationResponse?: MutationResponseResolvers<ContextType>;
   Organisation?: OrganisationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   RecordsProcessedEvent?: RecordsProcessedEventResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
+  UpsertMapViewResponse?: UpsertMapViewResponseResolvers<ContextType>;
 };
 
 export type DirectiveResolvers<ContextType = GraphQLContext> = {

--- a/src/app/(private)/map/components/Choropleth.tsx
+++ b/src/app/(private)/map/components/Choropleth.tsx
@@ -66,7 +66,7 @@ export default function Choropleth() {
             "text-font": ["DIN Pro Medium", "Arial Unicode MS Bold"],
           }}
           paint={{
-            "text-color": mapConfig.mapStyle.textColor,
+            "text-color": mapConfig.getMapStyle().textColor,
             "text-opacity": [
               "interpolate",
               ["linear"],
@@ -76,7 +76,7 @@ export default function Choropleth() {
               10,
               0.8,
             ],
-            "text-halo-color": mapConfig.mapStyle.textHaloColor,
+            "text-halo-color": mapConfig.getMapStyle().textHaloColor,
             "text-halo-width": 1.5,
           }}
         />

--- a/src/app/(private)/map/components/Map.tsx
+++ b/src/app/(private)/map/components/Map.tsx
@@ -52,7 +52,7 @@ export default function Map({
       ref={mapRef}
       style={{ flexGrow: 1 }}
       mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}
-      mapStyle={`mapbox://styles/mapbox/${mapConfig.mapStyle.slug}`}
+      mapStyle={`mapbox://styles/mapbox/${mapConfig.getMapStyle().slug}`}
       onClick={(e) => {
         const map = e.target;
         const features = map.queryRenderedFeatures(e.point, {
@@ -190,6 +190,10 @@ export default function Map({
         if (e.sourceId && MAPBOX_SOURCE_IDS.includes(e.sourceId)) {
           onSourceLoad(e.sourceId);
         }
+      }}
+      onStyleData={(e) => {
+        /* @ts-expect-error The style property is missing in the MapBox type definitions */
+        onSourceLoad(e.style.globalId);
       }}
     >
       <Choropleth />

--- a/src/app/(private)/map/components/MapStyleSelector.tsx
+++ b/src/app/(private)/map/components/MapStyleSelector.tsx
@@ -1,5 +1,6 @@
 import { Paintbrush, Scan, Type } from "lucide-react";
 import { useContext } from "react";
+import { MapStyleName } from "@/__generated__/types";
 import { MapContext } from "@/app/(private)/map/context/MapContext";
 import { Label } from "@/shadcn/ui/label";
 import {
@@ -25,10 +26,10 @@ export default function MapStyleSelector() {
         <TooltipProvider>
           <Tooltip>
             <Select
-              value={mapConfig.mapStyle.slug}
+              value={mapConfig.getMapStyle().name}
               onValueChange={(value) =>
                 updateMapConfig({
-                  mapStyle: mapStyles[value as keyof typeof mapStyles],
+                  mapStyleName: value as MapStyleName,
                 })
               }
             >
@@ -42,7 +43,7 @@ export default function MapStyleSelector() {
                 {Object.keys(mapStyles).map((code) => (
                   <SelectItem
                     key={code}
-                    value={mapStyles[code as keyof typeof mapStyles].slug}
+                    value={mapStyles[code as keyof typeof mapStyles].name}
                   >
                     {mapStyles[code as keyof typeof mapStyles].name}
                   </SelectItem>

--- a/src/app/(private)/map/components/controls/ChoroplethControl.tsx
+++ b/src/app/(private)/map/components/controls/ChoroplethControl.tsx
@@ -1,5 +1,6 @@
 import { CornerDownRight, LandPlot, SquareStack } from "lucide-react";
 import { useContext } from "react";
+import { AreaSetGroupCode } from "@/__generated__/types";
 import { MapContext } from "@/app/(private)/map/context/MapContext";
 import { MAX_COLUMN_KEY, NULL_UUID } from "@/constants";
 import { Label } from "@/shadcn/ui/label";
@@ -10,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/shadcn/ui/select";
-import { AREA_SET_GROUP_LABELS, AreaSetGroupCode } from "../../sources";
+import { AREA_SET_GROUP_LABELS } from "../../sources";
 
 export default function ChoroplethControl() {
   const { mapConfig, dataSourcesQuery, updateMapConfig } =

--- a/src/app/(private)/map/components/controls/Controls.tsx
+++ b/src/app/(private)/map/components/controls/Controls.tsx
@@ -1,3 +1,12 @@
+import { gql, useMutation } from "@apollo/client";
+import { useContext, useState } from "react";
+import {
+  UpsertMapViewMutation,
+  UpsertMapViewMutationVariables,
+} from "@/__generated__/types";
+import { MapContext } from "@/app/(private)/map/context/MapContext";
+import { OrganisationsContext } from "@/providers/OrganisationsProvider";
+import { Button } from "@/shadcn/ui/button";
 import { Separator } from "@/shadcn/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shadcn/ui/tabs";
 import ChoroplethControl from "./ChoroplethControl";
@@ -6,6 +15,50 @@ import MembersControl from "./MembersControl";
 import TurfControl from "./TurfControl";
 
 export default function Controls() {
+  const { mapConfig, viewId, setViewId } = useContext(MapContext);
+  const { organisationId } = useContext(OrganisationsContext);
+  const [loading, setLoading] = useState(false);
+  const [saveError, setSaveError] = useState("");
+
+  const [upsertMapConfig] = useMutation<
+    UpsertMapViewMutation,
+    UpsertMapViewMutationVariables
+  >(gql`
+    mutation UpsertMapView(
+      $id: String
+      $config: MapConfigInput!
+      $organisationId: String!
+    ) {
+      upsertMapView(id: $id, config: $config, organisationId: $organisationId) {
+        code
+        result
+      }
+    }
+  `);
+
+  const saveMapConfig = async () => {
+    // Should never happen, button is also hidden in this case
+    if (!organisationId) {
+      return;
+    }
+
+    setLoading(true);
+    setSaveError("");
+    try {
+      const result = await upsertMapConfig({
+        variables: { id: viewId, config: mapConfig, organisationId },
+      });
+      if (!result.data?.upsertMapView?.result) {
+        throw new Error(String(result.errors || "Unknown error"));
+      }
+      setViewId(result.data.upsertMapView.result);
+    } catch (e) {
+      console.error("UpsertMapView failed", e);
+      setSaveError("Could not save this map view, please try again.");
+    }
+    setLoading(false);
+  };
+
   return (
     <div className="flex flex-col bg-white rounded-lg shadow-lg gap-4 absolute top-0 left-0 m-3 p-4 z-10 w-[300px]">
       <Tabs defaultValue="Layers" className="w-full">
@@ -33,6 +86,19 @@ export default function Controls() {
           <ChoroplethControl />
         </TabsContent>
       </Tabs>
+      {organisationId && (
+        <div className="flex flex-col gap-4">
+          <Button
+            className="cursor-pointer"
+            type="button"
+            onClick={() => saveMapConfig()}
+            disabled={loading}
+          >
+            Save
+          </Button>
+          {saveError && <span>{saveError}</span>}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(private)/map/context/MapContext.tsx
+++ b/src/app/(private)/map/context/MapContext.tsx
@@ -2,28 +2,27 @@ import { QueryResult } from "@apollo/client";
 import { RefObject, createContext } from "react";
 import { MapRef } from "react-map-gl/mapbox";
 import {
+  AreaSetGroupCode,
   AreaStatsQuery,
   AreaStatsQueryVariables,
   BoundingBoxInput,
   DataSourcesQuery,
+  MapConfigInput,
+  MapStyleName,
 } from "@/__generated__/types";
 import { DEFAULT_ZOOM } from "@/constants";
 import { DrawnPolygon, MarkerData, SearchResult } from "@/types";
-import {
-  AreaSetGroupCode,
-  ChoroplethLayerConfig,
-  getChoroplethLayerConfig,
-} from "../sources";
-import mapStyles, { MapStyle } from "../styles";
+import { ChoroplethLayerConfig, getChoroplethLayerConfig } from "../sources";
+import mapStyles from "../styles";
 import { MarkersQueryResult } from "../types";
 
-export class MapConfig {
+export class MapConfig implements MapConfigInput {
   public areaDataSourceId = "";
   public areaDataColumn = "";
-  public areaSetGroupCode: AreaSetGroupCode = "WMC24";
+  public areaSetGroupCode: AreaSetGroupCode = AreaSetGroupCode.WMC24;
   public excludeColumnsString = "";
   public markersDataSourceId = "";
-  public mapStyle: MapStyle = mapStyles["light-v11"];
+  public mapStyleName: MapStyleName = MapStyleName.Light;
   public showLabels = true;
   public showBoundaryOutline = false;
   public showMembers = true;
@@ -39,6 +38,10 @@ export class MapConfig {
       .split(",")
       .map((v) => v.trim())
       .filter(Boolean);
+  }
+
+  getMapStyle() {
+    return mapStyles[this.mapStyleName] || Object.values(mapStyles)[0];
   }
 }
 
@@ -68,6 +71,9 @@ export const MapContext = createContext<{
     turfHistory: DrawnPolygon[] | ((prev: DrawnPolygon[]) => DrawnPolygon[]),
   ) => void;
 
+  viewId: string | null;
+  setViewId: (id: string) => void;
+
   zoom: number;
   setZoom: (zoom: number) => void;
 
@@ -93,6 +99,8 @@ export const MapContext = createContext<{
   setSelectedMarker: () => null,
   turfHistory: [],
   setTurfHistory: () => null,
+  viewId: null,
+  setViewId: () => null,
   zoom: DEFAULT_ZOOM,
   setZoom: () => null,
 
@@ -100,6 +108,9 @@ export const MapContext = createContext<{
   dataSourcesQuery: null,
   markersQuery: null,
 
-  choroplethLayerConfig: getChoroplethLayerConfig("WMC24", DEFAULT_ZOOM),
+  choroplethLayerConfig: getChoroplethLayerConfig(
+    AreaSetGroupCode.WMC24,
+    DEFAULT_ZOOM,
+  ),
   updateMapConfig: () => null,
 });

--- a/src/app/(private)/map/data.ts
+++ b/src/app/(private)/map/data.ts
@@ -5,6 +5,7 @@ import {
   AreaStatsQuery,
   AreaStatsQueryVariables,
   DataSourcesQuery,
+  MapViewsQuery,
   Operation,
 } from "@/__generated__/types";
 import { PointFeature } from "@/types";
@@ -23,6 +24,31 @@ export const useDataSourcesQuery = () =>
       }
     }
   `);
+
+export const useMapViewsQuery = (organisationId: string | null) =>
+  useQuery<MapViewsQuery>(
+    gql`
+      query MapViews($organisationId: String!) {
+        mapViews(organisationId: $organisationId) {
+          id
+          config {
+            areaDataSourceId
+            areaDataColumn
+            areaSetGroupCode
+            excludeColumnsString
+            markersDataSourceId
+            mapStyleName
+            showBoundaryOutline
+            showLabels
+            showLocations
+            showMembers
+            showTurf
+          }
+        }
+      }
+    `,
+    { variables: { organisationId }, skip: !organisationId },
+  );
 
 // Use API request instead of GraphQL to avoid server memory load
 // TODO: replace with gql @stream directive when Apollo client supports it

--- a/src/app/(private)/map/page.tsx
+++ b/src/app/(private)/map/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { MapRef } from "react-map-gl/mapbox";
 import { BoundingBoxInput } from "@/__generated__/types";
 import { MapConfig, MapContext } from "@/app/(private)/map/context/MapContext";
 import { DEFAULT_ZOOM } from "@/constants";
+import { OrganisationsContext } from "@/providers/OrganisationsProvider";
 import { DrawnPolygon, MarkerData, SearchResult } from "@/types";
 import Controls from "./components/controls/Controls";
 import Legend from "./components/Legend";
@@ -14,12 +15,14 @@ import MapStyleSelector from "./components/MapStyleSelector";
 import {
   useAreaStatsQuery,
   useDataSourcesQuery,
+  useMapViewsQuery,
   useMarkersQuery,
 } from "./data";
 import styles from "./page.module.css";
 import { getChoroplethLayerConfig } from "./sources";
 
 export default function MapPage() {
+  const { organisationId } = useContext(OrganisationsContext);
   /* Map Ref */
   const mapRef = useRef<MapRef>(null);
 
@@ -33,50 +36,11 @@ export default function MapPage() {
     string | undefined
   >();
   const [mapConfig, setMapConfig] = useState(new MapConfig());
-  const [searchHistory, setSearchHistory] = useState<SearchResult[]>([
-    {
-      text: "Abbey Road Studios",
-      coordinates: [-0.177331, 51.532005],
-      timestamp: new Date(),
-    },
-  ]);
+  const [searchHistory, setSearchHistory] =
+    useState<SearchResult[]>(SAMPLE_MARKERS);
   const [selectedMarker, setSelectedMarker] = useState<MarkerData | null>(null);
-  const [turfHistory, setTurfHistory] = useState<DrawnPolygon[]>([
-    {
-      id: "N90IVwEVjjVuYnJwwtuPSvRgVTAUgLjh",
-      area: 6659289.77,
-      geometry: {
-        coordinates: [
-          [
-            [-0.09890821864360078, 51.466784423169656],
-            [-0.050307845722869615, 51.457615269748146],
-            [-0.06844742153057837, 51.496624718934044],
-            [-0.09890821864360078, 51.466784423169656],
-          ],
-        ],
-        type: "Polygon",
-      },
-      timestamp: new Date("2024-03-20T14:31:00Z"),
-      name: "Anti-austerity campaign area",
-    },
-    {
-      id: "qY9R13eRjlVUZQ5GyHIwroX2C2GZuA9g",
-      area: 14311817.59,
-      geometry: {
-        coordinates: [
-          [
-            [-0.1676382772736531, 51.454985375110425],
-            [-0.1028980072736374, 51.423675158113724],
-            [-0.09285210330847349, 51.476194541881796],
-            [-0.1676382772736531, 51.454985375110425],
-          ],
-        ],
-        type: "Polygon",
-      },
-      timestamp: new Date(),
-      name: "Sallys turf",
-    },
-  ]);
+  const [turfHistory, setTurfHistory] = useState<DrawnPolygon[]>(SAMPLE_TURF);
+  const [viewId, setViewId] = useState<string | null>(null);
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
 
   /* Derived State */
@@ -90,6 +54,8 @@ export default function MapPage() {
 
   /* GraphQL Data */
   const dataSourcesQuery = useDataSourcesQuery();
+  const { data: mapViewsData, loading: mapViewsLoading } =
+    useMapViewsQuery(organisationId);
 
   const markersQuery = useMarkersQuery({
     dataSourceId: mapConfig.markersDataSourceId,
@@ -104,6 +70,17 @@ export default function MapPage() {
   });
 
   const { data: areaStatsData, fetchMore: areaStatsFetchMore } = areaStatsQuery;
+
+  /* Update local map state when saved views are loaded from the server */
+  useEffect(() => {
+    if (mapViewsData?.mapViews && mapViewsData.mapViews.length > 0) {
+      const nextViewId = mapViewsData?.mapViews[0].id;
+      const nextConfig = { ...mapViewsData?.mapViews[0].config };
+      delete nextConfig.__typename;
+      setViewId(nextViewId);
+      setMapConfig(new MapConfig(nextConfig));
+    }
+  }, [mapViewsData]);
 
   /* Set Mapbox feature state on receiving new AreaStats */
   useEffect(() => {
@@ -138,10 +115,19 @@ export default function MapPage() {
     areaStatsFetchMore({ variables: { boundingBox } });
   }, [areaStatsFetchMore, boundingBox, choroplethLayerConfig, mapConfig]);
 
+  // Don't display any components while waiting for saved map views
+  if (mapViewsLoading) {
+    return (
+      <div className={styles.map}>
+        <div className={styles.loading}>
+          <div></div>
+        </div>
+      </div>
+    );
+  }
+
   const loading =
-    areaStatsQuery?.loading ||
-    dataSourcesQuery?.loading ||
-    markersQuery?.loading;
+    areaStatsQuery.loading || dataSourcesQuery.loading || markersQuery.loading;
 
   return (
     <MapContext
@@ -159,6 +145,8 @@ export default function MapPage() {
         setSelectedMarker,
         turfHistory,
         setTurfHistory,
+        viewId,
+        setViewId,
         zoom,
         setZoom,
 
@@ -184,3 +172,48 @@ export default function MapPage() {
     </MapContext>
   );
 }
+
+const SAMPLE_MARKERS: SearchResult[] = [
+  {
+    text: "Abbey Road Studios",
+    coordinates: [-0.177331, 51.532005],
+    timestamp: new Date(),
+  },
+];
+
+const SAMPLE_TURF: DrawnPolygon[] = [
+  {
+    id: "N90IVwEVjjVuYnJwwtuPSvRgVTAUgLjh",
+    area: 6659289.77,
+    geometry: {
+      coordinates: [
+        [
+          [-0.09890821864360078, 51.466784423169656],
+          [-0.050307845722869615, 51.457615269748146],
+          [-0.06844742153057837, 51.496624718934044],
+          [-0.09890821864360078, 51.466784423169656],
+        ],
+      ],
+      type: "Polygon",
+    },
+    timestamp: new Date("2024-03-20T14:31:00Z"),
+    name: "Anti-austerity campaign area",
+  },
+  {
+    id: "qY9R13eRjlVUZQ5GyHIwroX2C2GZuA9g",
+    area: 14311817.59,
+    geometry: {
+      coordinates: [
+        [
+          [-0.1676382772736531, 51.454985375110425],
+          [-0.1028980072736374, 51.423675158113724],
+          [-0.09285210330847349, 51.476194541881796],
+          [-0.1676382772736531, 51.454985375110425],
+        ],
+      ],
+      type: "Polygon",
+    },
+    timestamp: new Date(),
+    name: "Sallys turf",
+  },
+];

--- a/src/app/(private)/map/sources.ts
+++ b/src/app/(private)/map/sources.ts
@@ -1,11 +1,9 @@
-import { AreaSetCode } from "@/__generated__/types";
+import { AreaSetCode, AreaSetGroupCode } from "@/__generated__/types";
 
-export const AREA_SET_GROUP_LABELS = {
+export const AREA_SET_GROUP_LABELS: Record<AreaSetGroupCode, string> = {
   WMC24: "Westminster Constituencies 2024",
   OA21: "Census Output Areas 2021",
 };
-
-export type AreaSetGroupCode = keyof typeof AREA_SET_GROUP_LABELS;
 
 const MAX_VALID_ZOOM = 24;
 

--- a/src/app/(private)/map/styles.ts
+++ b/src/app/(private)/map/styles.ts
@@ -1,30 +1,32 @@
-export interface MapStyle {
+import { MapStyleName } from "@/__generated__/types";
+
+export interface MapStyleConfig {
   name: string;
   slug: string;
   textColor: string;
   textHaloColor: string;
 }
 
-const mapStyles: Record<string, MapStyle> = {
-  "light-v11": {
+const mapStyles: Record<MapStyleName, MapStyleConfig> = {
+  Light: {
     name: "Light",
     slug: "light-v11",
     textColor: "#6D6D6D",
     textHaloColor: "#ffffff",
   },
-  "dark-v11": {
+  Dark: {
     name: "Dark",
     slug: "dark-v11",
     textColor: "#ffffff",
     textHaloColor: "#000000",
   },
-  "streets-v12": {
+  Streets: {
     name: "Streets",
     slug: "streets-v12",
     textColor: "#6D6D6D",
     textHaloColor: "#ffffff",
   },
-  "satellite-v9": {
+  Satellite: {
     name: "Satellite",
     slug: "satellite-v9",
     textColor: "#ffffff",

--- a/src/app/api/graphql/resolvers/Query.ts
+++ b/src/app/api/graphql/resolvers/Query.ts
@@ -9,6 +9,7 @@ import {
   findDataSourceById,
   findDataSourcesByUserId,
 } from "@/server/repositories/DataSource";
+import { findMapViewsByOrganisationId } from "@/server/repositories/MapView";
 import { findOrganisationsByUserId } from "@/server/repositories/Organisation";
 import { getAreaStats } from "@/server/stats";
 
@@ -60,6 +61,16 @@ const QueryResolvers: QueryResolversType = {
     return dataSources
       .filter((ds) => !organisationId || ds.organisationId === organisationId)
       .map(serializeDataSource);
+  },
+
+  mapViews: async (
+    _: unknown,
+    { organisationId }: { organisationId?: string | null },
+  ) => {
+    if (!organisationId) {
+      return [];
+    }
+    return findMapViewsByOrganisationId(organisationId);
   },
 
   organisations: async (_: unknown, args: unknown, context: GraphQLContext) => {

--- a/src/app/api/graphql/typeDefs/index.ts
+++ b/src/app/api/graphql/typeDefs/index.ts
@@ -10,6 +10,11 @@ const typeDefs = `
     WMC24
   }
 
+  enum AreaSetGroupCode {
+    OA21
+    WMC24
+  }
+
   enum ColumnType {
     Empty
     Boolean
@@ -37,6 +42,13 @@ const typeDefs = `
     Running
     Complete
     Pending
+  }
+
+  enum MapStyleName {
+    Light
+    Dark
+    Streets
+    Satellite
   }
 
   enum Operation {
@@ -72,6 +84,20 @@ const typeDefs = `
     areaProperty: String
     dataSourceId: String
     dataSourceColumn: String
+  }
+
+  input MapConfigInput {
+    areaDataSourceId: String
+    areaDataColumn: String
+    areaSetGroupCode: AreaSetGroupCode
+    excludeColumnsString: String
+    markersDataSourceId: String
+    mapStyleName: MapStyleName
+    showBoundaryOutline: Boolean
+    showLabels: Boolean
+    showLocations: Boolean
+    showMembers: Boolean
+    showTurf: Boolean
   }
 
   type AreaStat {
@@ -146,6 +172,26 @@ const typeDefs = `
     dataSourceColumn: String
   }
 
+  type MapConfig {
+    areaDataSourceId: String!
+    areaDataColumn: String!
+    areaSetGroupCode: AreaSetGroupCode!
+    excludeColumnsString: String!
+    markersDataSourceId: String!
+    mapStyleName: MapStyleName!
+    showBoundaryOutline: Boolean!
+    showLabels: Boolean!
+    showLocations: Boolean!
+    showMembers: Boolean!
+    showTurf: Boolean!
+  }
+
+  type MapView {
+    id: String!
+    config: MapConfig!
+    organisationId: String!
+  }
+
   type Organisation {
     id: String!
     name: String!
@@ -164,6 +210,7 @@ const typeDefs = `
     dataSource(id: String!): DataSource @auth(read: { dataSourceIdArg: "id" })
     dataSources(organisationId: String): [DataSource!] @auth
 
+    mapViews(organisationId: String!): [MapView!] @auth(read: { organisationIdArg: "organisationId" })
     organisations: [Organisation!] @auth
   }
 
@@ -174,6 +221,11 @@ const typeDefs = `
 
   type MutationResponse {
     code: Int!
+  }
+
+  type UpsertMapViewResponse {
+    code: Int!
+    result: String
   }
 
   type Mutation {
@@ -192,6 +244,11 @@ const typeDefs = `
       looseGeocodingConfig: LooseGeocodingConfigInput
       looseEnrichments: [LooseEnrichmentInput!]
     ): MutationResponse @auth(write: { dataSourceIdArg: "id" })
+    upsertMapView(
+      id: String
+      config: MapConfigInput!
+      organisationId: String!
+    ): UpsertMapViewResponse @auth(write: { organisationIdArg: "organisationId" })
   }
 
   type DataSourceEvent {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -80,12 +80,14 @@ export default function Navbar() {
       ) : (
         <form onSubmit={onSubmitLogin}>
           <input
+            name="email"
             type="email"
             placeholder="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
           />
           <input
+            name="password"
             type="password"
             placeholder="password"
             value={password}

--- a/src/server/models/DataSource.ts
+++ b/src/server/models/DataSource.ts
@@ -7,7 +7,6 @@ import {
   Updateable,
 } from "kysely";
 import { ColumnDef, ColumnRoles } from "@/__generated__/types";
-import { DataSourceType } from "@/types";
 import { DataSourceConfig, Enrichment, GeocodingConfig } from "@/zod";
 
 export interface DataSourceTable {
@@ -27,24 +26,3 @@ export interface DataSourceTable {
 export type DataSource = Selectable<DataSourceTable>;
 export type NewDataSource = Insertable<DataSourceTable>;
 export type DataSourceUpdate = Updateable<DataSourceTable>;
-
-export const DataSourceFeatures: Record<
-  DataSourceType,
-  { autoEnrich: boolean; autoImport: boolean; enrichment: boolean }
-> = {
-  [DataSourceType.airtable]: {
-    autoEnrich: true,
-    autoImport: true,
-    enrichment: true,
-  },
-  [DataSourceType.csv]: {
-    autoEnrich: false,
-    autoImport: false,
-    enrichment: false,
-  },
-  [DataSourceType.mailchimp]: {
-    autoEnrich: true,
-    autoImport: true,
-    enrichment: true,
-  },
-};

--- a/src/server/models/MapView.ts
+++ b/src/server/models/MapView.ts
@@ -1,0 +1,20 @@
+import {
+  Generated,
+  Insertable,
+  JSONColumnType,
+  ColumnType as KyselyColumnType,
+  Selectable,
+  Updateable,
+} from "kysely";
+import { MapConfig } from "@/__generated__/types";
+
+export interface MapViewTable {
+  id: Generated<string>;
+  config: JSONColumnType<MapConfig>;
+  organisationId: string;
+  createdAt: KyselyColumnType<Date, string | undefined, never>;
+}
+
+export type MapView = Selectable<MapViewTable>;
+export type NewMapView = Insertable<MapViewTable>;
+export type MapViewUpdate = Updateable<MapViewTable>;

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -4,6 +4,7 @@ import { AreaSetTable } from "./AreaSet";
 import { DataRecordTable } from "./DataRecord";
 import { DataSourceTable } from "./DataSource";
 import { JobTable } from "./Job";
+import { MapViewTable } from "./MapView";
 import { OrganisationTable } from "./Organisation";
 import { OrganisationUserTable } from "./OrganisationUser";
 import { UserTable } from "./User";
@@ -14,6 +15,7 @@ export interface Database {
   areaSet: AreaSetTable;
   dataSource: DataSourceTable;
   dataRecord: DataRecordTable;
+  mapView: MapViewTable;
   organisation: OrganisationTable;
   organisationUser: OrganisationUserTable;
   user: UserTable;

--- a/src/server/repositories/MapView.ts
+++ b/src/server/repositories/MapView.ts
@@ -1,0 +1,28 @@
+import { MapViewUpdate, NewMapView } from "@/server/models/MapView";
+import { db } from "@/server/services/database";
+
+export async function findMapViewsByOrganisationId(organisationId: string) {
+  return await db
+    .selectFrom("mapView")
+    .where("organisationId", "=", organisationId)
+    .orderBy("id asc")
+    .selectAll()
+    .execute();
+}
+
+export function insertMapView(mapView: NewMapView) {
+  return db
+    .insertInto("mapView")
+    .values(mapView)
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}
+
+export function updateMapView(id: string, updateWith: MapViewUpdate) {
+  return db
+    .updateTable("mapView")
+    .set(updateWith)
+    .where("id", "=", id)
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}


### PR DESCRIPTION
## Description
Preparatory work for map views.

- Adds a `map_view` table to the database, views are per organisation
- Loads the first MapView for the current org on front-end map load
- Adds a save button to persist changes to the view to the database
