### PR TITLE
refactor: split map state up into providers

### DIFF
--- a/src/app/(private)/map/[id]/MapPage.tsx
+++ b/src/app/(private)/map/[id]/MapPage.tsx
@@ -1,21 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useContext } from "react";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { MapRef } from "react-map-gl/mapbox";
-import { BoundingBoxInput, SortInput, Turf } from "@/__generated__/types";
-import {
-  MapContext,
-  ViewConfig,
-} from "@/app/(private)/map/[id]/context/MapContext";
 import MapNavbar from "@/components/MapNavbar";
-import { DEFAULT_ZOOM } from "@/constants";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/shadcn/ui/resizable";
-import { MarkerData } from "@/types";
 import ChoroplethControl from "./components/controls/ChoroplethControl";
 import Controls from "./components/controls/Controls";
 import Legend from "./components/Legend";
@@ -23,269 +15,55 @@ import Loading from "./components/Loading";
 import Map from "./components/Map";
 import MapStyleSelector from "./components/MapStyleSelector";
 import MapTable from "./components/table/MapTable";
-import {
-  useAreaStatsQuery,
-  useDataRecordsQuery,
-  useDataSourcesQuery,
-  useMapQuery,
-  useMarkerQueries,
-} from "./data";
-import { usePlacedMarkers, useTurfs } from "./hooks";
-import styles from "./MapPage.module.css";
-import { getChoroplethLayerConfig } from "./sources";
+import { ChoroplethContext } from "./context/ChoroplethContext";
+import { MapContext } from "./context/MapContext";
+import { MarkerAndTurfContext } from "./context/MarkerAndTurfContext";
+import { TableContext } from "./context/TableContext";
 
-export default function MapPage({ mapId }: { mapId: string }) {
-  /* Map Ref */
-  const mapRef = useRef<MapRef>(null);
-  const [mapName, setMapName] = useState<string | null>(null);
+export default function MapPage() {
+  const { dataSourcesQuery, mapQuery, mapRef } = useContext(MapContext);
+  const { areaStatsLoading, areaStatsQuery, setLastLoadedSourceId } =
+    useContext(ChoroplethContext);
+  const { markerQueries } = useContext(MarkerAndTurfContext);
+  const { selectedDataSourceId } = useContext(TableContext);
 
-  /* Map State */
-  // Keep track of area codes that have feature state, to clean if necessary
-  const areaCodesToClean = useRef<Record<string, boolean>>({});
-  // Manually keep track of fetchMore loading state as the first fetchMore
-  // doesn't trigger the query loading flag
-  const [areaStatsLoading, setAreaStatsLoading] = useState(false);
-  const [boundingBox, setBoundingBox] = useState<BoundingBoxInput | null>(null);
-  const [editingTurf, setEditingTurf] = useState<Turf | null>(null);
-  // Storing the last loaded source triggers re-render when Mapbox layers load
-  const [lastLoadedSourceId, setLastLoadedSourceId] = useState<
-    string | undefined
-  >();
-  const [viewConfig, setViewConfig] = useState(new ViewConfig());
-  const [selectedMarker, setSelectedMarker] = useState<MarkerData | null>(null);
-  const [viewId, setViewId] = useState<string | null>(null);
-  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
-
-  const [selectedDataSourceId, setSelectedDataSourceId] = useState<string>("");
-  const [selectedRecordId, setSelectedRecordId] = useState<string | null>(null);
-
-  const [tableFilter, setTableFilter] = useState("");
-  const [tablePage, setTablePage] = useState(0);
-  const [tableSort, setTableSort] = useState<SortInput[]>([]);
-
-  const [boundariesPanelOpen, setBoundariesPanelOpen] = useState(false);
-  /* Derived State */
-  const choroplethLayerConfig = useMemo(() => {
-    return getChoroplethLayerConfig(viewConfig.areaSetGroupCode, zoom);
-  }, [viewConfig.areaSetGroupCode, zoom]);
-
-  /* GraphQL Data */
-  const dataSourcesQuery = useDataSourcesQuery();
-  const { data: mapData, loading: mapQueryLoading } = useMapQuery(mapId);
-
-  const markerQueries = useMarkerQueries({
-    membersDataSourceId: viewConfig.membersDataSourceId,
-    markerDataSourceIds: viewConfig.markerDataSourceIds,
-  });
-
-  const dataRecordsQuery = useDataRecordsQuery({
-    dataSourceId: selectedDataSourceId,
-    page: tablePage,
-    filter: tableFilter,
-    sort: tableSort,
-  });
-
-  const areaStatsQuery = useAreaStatsQuery({
-    areaSetCode: choroplethLayerConfig.areaSetCode,
-    dataSourceId: viewConfig.areaDataSourceId,
-    column: viewConfig.areaDataColumn,
-    excludeColumns: viewConfig.getExcludeColumns(),
-    useDummyBoundingBox: choroplethLayerConfig.requiresBoundingBox,
-  });
-
-  const { data: areaStatsData, fetchMore: areaStatsFetchMore } = areaStatsQuery;
-
-  /* Persisted map features */
-  const {
-    turfs,
-    setTurfs,
-    deleteTurf,
-    insertTurf,
-    updateTurf,
-    loading: turfsLoading,
-  } = useTurfs(mapId);
-
-  const {
-    placedMarkers,
-    setPlacedMarkers,
-    deletePlacedMarker,
-    insertPlacedMarker,
-    updatePlacedMarker,
-    loading: placedMarkersLoading,
-  } = usePlacedMarkers(mapId);
-
-  const updateViewConfig = (nextViewConfig: Partial<ViewConfig>) => {
-    setViewConfig(new ViewConfig({ ...viewConfig, ...nextViewConfig }));
-  };
-
-  const handleDataSourceSelect = (dataSourceId: string) => {
-    if (selectedDataSourceId === dataSourceId) {
-      setSelectedDataSourceId("");
-      return;
-    }
-    setSelectedDataSourceId(dataSourceId);
-  };
-
-  /* Effects */
-
-  /* Update local map state when saved views are loaded from the server */
-  useEffect(() => {
-    setMapName(mapData?.map?.name || "Untitled");
-    if (mapData?.map?.views && mapData.map.views.length > 0) {
-      const nextView = mapData.map.views[0];
-      const nextViewId = nextView.id;
-      // Annoying workaround to remove __typename from read-only object (breaks `new ViewConfig()`)
-      const nextConfig = { ...nextView.config };
-      delete nextConfig.__typename;
-      setViewId(nextViewId);
-      setViewConfig(new ViewConfig(nextConfig));
-    }
-    if (mapData?.map?.placedMarkers) {
-      setPlacedMarkers(mapData.map.placedMarkers);
-    }
-    if (mapData?.map?.turfs) {
-      setTurfs(mapData.map.turfs);
-    }
-  }, [mapData, setPlacedMarkers, setTurfs]);
-
-  /* Set Mapbox feature state on receiving new AreaStats */
-  useEffect(() => {
-    if (!areaStatsData) {
-      return;
-    }
-
-    if (mapRef?.current?.getSource(choroplethLayerConfig.mapbox.sourceId)) {
-      const nextAreaCodesToClean: Record<string, boolean> = {};
-      areaStatsData.areaStats?.stats.forEach((stat) => {
-        mapRef?.current?.setFeatureState(
-          {
-            source: choroplethLayerConfig.mapbox.sourceId,
-            sourceLayer: choroplethLayerConfig.mapbox.layerId,
-            id: stat.areaCode,
-          },
-          stat,
-        );
-        nextAreaCodesToClean[stat.areaCode] = true;
-      });
-      // Remove lingering feature states
-      for (const areaCode in Object.keys(areaCodesToClean.current)) {
-        if (!nextAreaCodesToClean[areaCode]) {
-          mapRef?.current?.removeFeatureState({
-            source: choroplethLayerConfig.mapbox.sourceId,
-            sourceLayer: choroplethLayerConfig.mapbox.layerId,
-            id: areaCode,
-          });
-        }
-      }
-      areaCodesToClean.current = nextAreaCodesToClean;
-    }
-  }, [areaStatsData, choroplethLayerConfig, lastLoadedSourceId, mapRef]);
-
-  /* Do fetchMore() (if layer needs it) when bounding box or config changes */
-  useEffect(() => {
-    if (!choroplethLayerConfig.requiresBoundingBox || !areaStatsFetchMore) {
-      return;
-    }
-    (async () => {
-      setAreaStatsLoading(true);
-      await areaStatsFetchMore({ variables: { boundingBox } });
-      setAreaStatsLoading(false);
-    })();
-  }, [areaStatsFetchMore, boundingBox, choroplethLayerConfig, viewConfig]);
-
-  // Don't display any components while waiting for saved map views
-  if (mapQueryLoading) {
-    return (
-      <div className={styles.map}>
-        <Loading />
-      </div>
-    );
+  if (!mapQuery || mapQuery.loading) {
+    return <Loading />;
   }
 
   const loading =
     areaStatsLoading ||
-    areaStatsQuery.loading ||
-    dataSourcesQuery.loading ||
-    markerQueries.loading;
+    areaStatsQuery?.loading ||
+    dataSourcesQuery?.loading ||
+    markerQueries?.loading;
 
   return (
-    <MapContext
-      value={{
-        mapId,
-        mapName,
-        setMapName,
-        mapRef,
-
-        boundingBox,
-        setBoundingBox,
-        editingTurf,
-        setEditingTurf,
-        placedMarkers,
-        placedMarkersLoading,
-        deletePlacedMarker,
-        insertPlacedMarker,
-        updatePlacedMarker,
-        selectedMarker,
-        setSelectedMarker,
-        tableFilter,
-        setTableFilter,
-        tablePage,
-        setTablePage,
-        tableSort,
-        setTableSort,
-        turfs,
-        turfsLoading,
-        deleteTurf,
-        insertTurf,
-        updateTurf,
-        viewConfig,
-        updateViewConfig,
-        viewId,
-        setViewId,
-        zoom,
-        setZoom,
-
-        areaStatsQuery,
-        dataSourcesQuery,
-        dataRecordsQuery,
-        markerQueries,
-
-        choroplethLayerConfig,
-        selectedDataSourceId,
-        handleDataSourceSelect,
-        selectedRecordId,
-        setSelectedRecordId,
-        boundariesPanelOpen,
-        setBoundariesPanelOpen,
-      }}
-    >
-      <div className="flex flex-col h-screen">
-        <MapNavbar />
-        <div className="flex w-full grow min-h-0 relative">
-          <Controls />
-          <div className="flex flex-col gap-4 grow relative min-w-0">
-            <ResizablePanelGroup direction="vertical">
-              <ResizablePanel className="relative">
-                <Map
-                  onSourceLoad={(sourceId) => setLastLoadedSourceId(sourceId)}
-                />
-                <MapStyleSelector />
-                <ChoroplethControl />
-                <Legend areaStats={areaStatsData?.areaStats} />
-              </ResizablePanel>
-              {selectedDataSourceId && (
-                <>
-                  <ResizableHandle withHandle />
-                  <ResizablePanel onResize={() => mapRef.current?.resize()}>
-                    <MapTable />
-                  </ResizablePanel>
-                </>
-              )}
-            </ResizablePanelGroup>
-          </div>
-          {loading && <Loading />}
+    <div className="flex flex-col h-screen">
+      <MapNavbar />
+      <div className="flex w-full grow min-h-0 relative">
+        <Controls />
+        <div className="flex flex-col gap-4 grow relative min-w-0">
+          <ResizablePanelGroup direction="vertical">
+            <ResizablePanel className="relative">
+              <Map
+                onSourceLoad={(sourceId) => setLastLoadedSourceId(sourceId)}
+              />
+              <MapStyleSelector />
+              <ChoroplethControl />
+              <Legend areaStats={areaStatsQuery?.data?.areaStats} />
+            </ResizablePanel>
+            {selectedDataSourceId && (
+              <>
+                <ResizableHandle withHandle />
+                <ResizablePanel onResize={() => mapRef?.current?.resize()}>
+                  <MapTable />
+                </ResizablePanel>
+              </>
+            )}
+          </ResizablePanelGroup>
         </div>
+        {loading && <Loading />}
       </div>
-    </MapContext>
+    </div>
   );
 }

--- a/src/app/(private)/map/[id]/components/Choropleth.tsx
+++ b/src/app/(private)/map/[id]/components/Choropleth.tsx
@@ -1,16 +1,17 @@
 import { useContext } from "react";
 import { Layer, Source } from "react-map-gl/mapbox";
 import { useFillColor } from "@/app/(private)/map/[id]/colors";
+import { ChoroplethContext } from "@/app/(private)/map/[id]/context/ChoroplethContext";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
 
 export default function Choropleth() {
+  const { viewConfig } = useContext(MapContext);
   const {
-    viewConfig,
     choroplethLayerConfig: {
       mapbox: { featureCodeProperty, featureNameProperty, sourceId, layerId },
     },
     areaStatsQuery,
-  } = useContext(MapContext);
+  } = useContext(ChoroplethContext);
   const fillColor = useFillColor(areaStatsQuery?.data?.areaStats);
   if (!viewConfig.areaSetGroupCode) {
     return null;

--- a/src/app/(private)/map/[id]/components/Map.tsx
+++ b/src/app/(private)/map/[id]/components/Map.tsx
@@ -7,6 +7,7 @@ import * as mapboxgl from "mapbox-gl";
 import { useContext, useEffect, useState } from "react";
 import MapGL from "react-map-gl/mapbox";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { MarkerAndTurfContext } from "@/app/(private)/map/[id]/context/MarkerAndTurfContext";
 import { MAPBOX_SOURCE_IDS } from "@/app/(private)/map/[id]/sources";
 import { mapColors } from "@/app/(private)/map/[id]/styles";
 import { DEFAULT_ZOOM } from "@/constants";
@@ -22,16 +23,11 @@ export default function Map({
 }: {
   onSourceLoad: (sourceId: string) => void;
 }) {
-  const {
-    mapRef,
-    viewConfig,
-    insertPlacedMarker,
-    setBoundingBox,
-    setSelectedMarker,
-    deleteTurf,
-    insertTurf,
-    setZoom,
-  } = useContext(MapContext);
+  const { mapRef, viewConfig, setBoundingBox, setZoom } =
+    useContext(MapContext);
+  const { insertPlacedMarker, setSelectedMarker, deleteTurf, insertTurf } =
+    useContext(MarkerAndTurfContext);
+
   const [draw, setDraw] = useState<MapboxDraw | null>(null);
   const [ready, setReady] = useState(false);
 

--- a/src/app/(private)/map/[id]/components/MapStyleSelector.tsx
+++ b/src/app/(private)/map/[id]/components/MapStyleSelector.tsx
@@ -1,6 +1,7 @@
 import { Paintbrush, Scan, Type } from "lucide-react";
 import { useContext } from "react";
 import { MapStyleName } from "@/__generated__/types";
+import { ChoroplethContext } from "@/app/(private)/map/[id]/context/ChoroplethContext";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
 import { Label } from "@/shadcn/ui/label";
 import {
@@ -19,12 +20,9 @@ import {
 import mapStyles from "../styles";
 
 export default function MapStyleSelector() {
-  const {
-    viewConfig,
-    updateViewConfig,
-    boundariesPanelOpen,
-    setBoundariesPanelOpen,
-  } = useContext(MapContext);
+  const { viewConfig, updateViewConfig } = useContext(MapContext);
+  const { boundariesPanelOpen, setBoundariesPanelOpen } =
+    useContext(ChoroplethContext);
   return (
     <div className="h-14 rounded-lg absolute left-1/2 bottom-8 -translate-x-1/2 py-2 px-4 z-10  bg-white  shadow-lg">
       <div className="flex gap-2 items-center h-full">

--- a/src/app/(private)/map/[id]/components/Markers.tsx
+++ b/src/app/(private)/map/[id]/components/Markers.tsx
@@ -1,12 +1,14 @@
 import { useContext } from "react";
 import { Layer, Source } from "react-map-gl/mapbox";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { MarkerAndTurfContext } from "@/app/(private)/map/[id]/context/MarkerAndTurfContext";
 import { MARKER_NAME_KEY } from "@/constants";
 import { mapColors } from "../styles";
 import { DataSourceMarkers as DataSourceMarkersType } from "../types";
 
 export default function Markers() {
-  const { markerQueries, viewConfig } = useContext(MapContext);
+  const { viewConfig } = useContext(MapContext);
+  const { markerQueries } = useContext(MarkerAndTurfContext);
 
   const memberMarkers = markerQueries?.data?.find(
     (ds) => ds.dataSourceId === viewConfig.membersDataSourceId,

--- a/src/app/(private)/map/[id]/components/PlacedMarkers.tsx
+++ b/src/app/(private)/map/[id]/components/PlacedMarkers.tsx
@@ -2,10 +2,13 @@ import { FeatureCollection, Point } from "geojson";
 import { useContext } from "react";
 import { Layer, Source } from "react-map-gl/mapbox";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { MarkerAndTurfContext } from "@/app/(private)/map/[id]/context/MarkerAndTurfContext";
 import { mapColors } from "@/app/(private)/map/[id]/styles";
 
 export default function PlacedMarkers() {
-  const { viewConfig, placedMarkers } = useContext(MapContext);
+  const { viewConfig } = useContext(MapContext);
+  const { placedMarkers } = useContext(MarkerAndTurfContext);
+
   const features: FeatureCollection<Point> = {
     type: "FeatureCollection",
     features: placedMarkers.map((marker) => ({

--- a/src/app/(private)/map/[id]/components/TurfPolygons.tsx
+++ b/src/app/(private)/map/[id]/components/TurfPolygons.tsx
@@ -2,10 +2,12 @@ import { FeatureCollection, Polygon } from "geojson";
 import { useContext } from "react";
 import { Layer, Source } from "react-map-gl/mapbox";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { MarkerAndTurfContext } from "@/app/(private)/map/[id]/context/MarkerAndTurfContext";
 import { mapColors } from "@/app/(private)/map/[id]/styles";
 
 export default function TurfPolygons() {
-  const { viewConfig, turfs } = useContext(MapContext);
+  const { viewConfig } = useContext(MapContext);
+  const { turfs } = useContext(MarkerAndTurfContext);
 
   const features: FeatureCollection<Polygon> = {
     type: "FeatureCollection",

--- a/src/app/(private)/map/[id]/components/controls/ChoroplethControl.tsx
+++ b/src/app/(private)/map/[id]/components/controls/ChoroplethControl.tsx
@@ -1,6 +1,7 @@
 import { CornerDownRight, PaintBucketIcon, Scan } from "lucide-react";
 import { useContext } from "react";
 import { AreaSetGroupCode } from "@/__generated__/types";
+import { ChoroplethContext } from "@/app/(private)/map/[id]/context/ChoroplethContext";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
 import { MAX_COLUMN_KEY, NULL_UUID } from "@/constants";
 import { Label } from "@/shadcn/ui/label";
@@ -14,12 +15,11 @@ import {
 import { AREA_SET_GROUP_LABELS } from "../../sources";
 
 export default function ChoroplethControl() {
-  const {
-    viewConfig,
-    dataSourcesQuery,
-    updateViewConfig,
-    boundariesPanelOpen,
-  } = useContext(MapContext);
+  const { viewConfig, dataSourcesQuery, updateViewConfig } =
+    useContext(MapContext);
+
+  const { boundariesPanelOpen } = useContext(ChoroplethContext);
+
   const dataSources = dataSourcesQuery?.data?.dataSources || [];
   const dataSource = dataSources.find(
     (ds) => ds.id === viewConfig.areaDataSourceId,

--- a/src/app/(private)/map/[id]/components/controls/Controls.tsx
+++ b/src/app/(private)/map/[id]/components/controls/Controls.tsx
@@ -1,8 +1,7 @@
 import { Columns } from "lucide-react";
 import { useContext, useEffect, useState } from "react";
-
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
-
+import { TableContext } from "@/app/(private)/map/[id]/context/TableContext";
 import { Button } from "@/shadcn/ui/button";
 import { Separator } from "@/shadcn/ui/separator";
 import MarkersControl from "./MarkersControl";
@@ -10,7 +9,8 @@ import MembersControl from "./MembersControl";
 import TurfControl from "./TurfControl";
 
 export default function Controls() {
-  const { mapRef, selectedDataSourceId } = useContext(MapContext);
+  const { mapRef } = useContext(MapContext);
+  const { selectedDataSourceId } = useContext(TableContext);
 
   const [showControls, setShowControls] = useState(true);
 

--- a/src/app/(private)/map/[id]/components/controls/MarkersControl.tsx
+++ b/src/app/(private)/map/[id]/components/controls/MarkersControl.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/navigation";
 import { useContext, useState } from "react";
 import { PlacedMarker } from "@/__generated__/types";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { MarkerAndTurfContext } from "@/app/(private)/map/[id]/context/MarkerAndTurfContext";
 import { mapColors } from "@/app/(private)/map/[id]/styles";
 import IconDropdownWithTooltip from "@/components/IconDropdownWithTooltip";
 import { Checkbox } from "@/shadcn/ui/checkbox";
@@ -18,11 +19,13 @@ import MarkerList from "../lists/MarkerList";
 import LayerHeader from "./LayerHeader";
 
 export default function MarkersControl() {
-  const { viewConfig, updateViewConfig, insertPlacedMarker, mapRef } =
-    useContext(MapContext);
+  const { viewConfig, updateViewConfig, mapRef } = useContext(MapContext);
+  const { insertPlacedMarker } = useContext(MarkerAndTurfContext);
+
   const [dataSourcesModalOpen, setDataSourcesModalOpen] =
     useState<boolean>(false);
   const router = useRouter();
+
   return (
     <div className="flex flex-col gap-1 px-4 pb-4">
       <DataSourcesModal

--- a/src/app/(private)/map/[id]/components/lists/MarkerList.tsx
+++ b/src/app/(private)/map/[id]/components/lists/MarkerList.tsx
@@ -1,6 +1,8 @@
 import { Check, Database, Pencil, Table, Trash2 } from "lucide-react";
 import { useContext, useState } from "react";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { MarkerAndTurfContext } from "@/app/(private)/map/[id]/context/MarkerAndTurfContext";
+import { TableContext } from "@/app/(private)/map/[id]/context/TableContext";
 import { Button } from "@/shadcn/ui/button";
 import {
   ContextMenu,
@@ -13,17 +15,18 @@ import DataSourceIcon from "../DataSourceIcon";
 import Loading from "../Loading";
 
 export default function MarkerList() {
+  const { mapRef, dataSourcesQuery, viewConfig } = useContext(MapContext);
+
   const {
-    mapRef,
-    dataSourcesQuery,
-    viewConfig,
     placedMarkers,
     placedMarkersLoading,
-    selectedDataSourceId,
-    handleDataSourceSelect,
     deletePlacedMarker,
     updatePlacedMarker,
-  } = useContext(MapContext);
+  } = useContext(MarkerAndTurfContext);
+
+  const { selectedDataSourceId, handleDataSourceSelect } =
+    useContext(TableContext);
+
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editText, setEditText] = useState("");
   const [contextMenuIndex, setContextMenuIndex] = useState<number | null>(null);

--- a/src/app/(private)/map/[id]/components/lists/MemberList.tsx
+++ b/src/app/(private)/map/[id]/components/lists/MemberList.tsx
@@ -1,17 +1,16 @@
 import { Table } from "lucide-react";
 import { useContext } from "react";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { TableContext } from "@/app/(private)/map/[id]/context/TableContext";
 import { ScrollArea } from "@/shadcn/ui/scroll-area";
 import DataSourceIcon from "../DataSourceIcon";
 import SkeletonGroup from "../SkeletonGroup";
 
 export default function MemberList() {
-  const {
-    dataSourcesQuery,
-    viewConfig,
-    selectedDataSourceId,
-    handleDataSourceSelect,
-  } = useContext(MapContext);
+  const { dataSourcesQuery, viewConfig } = useContext(MapContext);
+
+  const { selectedDataSourceId, handleDataSourceSelect } =
+    useContext(TableContext);
 
   const dataSource = dataSourcesQuery?.data?.dataSources?.find(
     (ds) => ds.id === viewConfig.membersDataSourceId,

--- a/src/app/(private)/map/[id]/components/lists/TurfList.tsx
+++ b/src/app/(private)/map/[id]/components/lists/TurfList.tsx
@@ -3,6 +3,7 @@ import { Check, Pencil, Trash2 } from "lucide-react";
 import { useContext, useEffect, useState } from "react";
 import { Turf } from "@/__generated__/types";
 import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { MarkerAndTurfContext } from "@/app/(private)/map/[id]/context/MarkerAndTurfContext";
 import { OrganisationsContext } from "@/providers/OrganisationsProvider";
 import { Button } from "@/shadcn/ui/button";
 import {
@@ -16,15 +17,9 @@ import Loading from "../Loading";
 
 export default function TurfList() {
   const { getOrganisation } = useContext(OrganisationsContext);
-  const {
-    viewConfig,
-    mapRef,
-    turfs,
-    turfsLoading,
-    setEditingTurf,
-    updateTurf,
-    deleteTurf,
-  } = useContext(MapContext);
+  const { viewConfig, mapRef } = useContext(MapContext);
+  const { turfs, turfsLoading, setEditingTurf, updateTurf, deleteTurf } =
+    useContext(MarkerAndTurfContext);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editText, setEditText] = useState("");
   const [contextMenuIndex, setContextMenuIndex] = useState<number | null>(null);

--- a/src/app/(private)/map/[id]/components/table/MapTable.tsx
+++ b/src/app/(private)/map/[id]/components/table/MapTable.tsx
@@ -1,5 +1,6 @@
 import { useContext } from "react";
-import { MapContext } from "../../context/MapContext";
+import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { TableContext } from "@/app/(private)/map/[id]/context/TableContext";
 import { DataTable } from "./DataTable";
 
 interface DataRecord {
@@ -8,8 +9,8 @@ interface DataRecord {
 }
 
 export default function MapTable() {
+  const { mapRef, dataSourcesQuery } = useContext(MapContext);
   const {
-    mapRef,
     selectedDataSourceId,
     handleDataSourceSelect,
     selectedRecordId,
@@ -21,8 +22,7 @@ export default function MapTable() {
     tableSort,
     setTableSort,
     dataRecordsQuery,
-    dataSourcesQuery,
-  } = useContext(MapContext);
+  } = useContext(TableContext);
 
   if (!selectedDataSourceId) {
     return null;

--- a/src/app/(private)/map/[id]/context/ChoroplethContext.tsx
+++ b/src/app/(private)/map/[id]/context/ChoroplethContext.tsx
@@ -1,0 +1,29 @@
+import { QueryResult } from "@apollo/client";
+import { createContext } from "react";
+import { AreaStatsQuery, AreaStatsQueryVariables } from "@/__generated__/types";
+import { DEFAULT_ZOOM } from "@/constants";
+import { ChoroplethLayerConfig, getChoroplethLayerConfig } from "../sources";
+
+export const ChoroplethContext = createContext<{
+  /* State */
+  boundariesPanelOpen: boolean;
+  setBoundariesPanelOpen: (open: boolean) => void;
+
+  lastLoadedSourceId: string | undefined;
+  setLastLoadedSourceId: (id: string) => void;
+
+  /* Queries */
+  areaStatsLoading: boolean;
+  areaStatsQuery: QueryResult<AreaStatsQuery, AreaStatsQueryVariables> | null;
+
+  /* Derived Properties */
+  choroplethLayerConfig: ChoroplethLayerConfig;
+}>({
+  boundariesPanelOpen: false,
+  setBoundariesPanelOpen: () => null,
+  choroplethLayerConfig: getChoroplethLayerConfig(null, DEFAULT_ZOOM),
+  lastLoadedSourceId: undefined,
+  setLastLoadedSourceId: () => null,
+  areaStatsLoading: false,
+  areaStatsQuery: null,
+});

--- a/src/app/(private)/map/[id]/context/MapContext.tsx
+++ b/src/app/(private)/map/[id]/context/MapContext.tsx
@@ -3,23 +3,15 @@ import { RefObject, createContext } from "react";
 import { MapRef } from "react-map-gl/mapbox";
 import {
   AreaSetGroupCode,
-  AreaStatsQuery,
-  AreaStatsQueryVariables,
   BoundingBoxInput,
-  DataRecordsQuery,
-  DataRecordsQueryVariables,
   DataSourcesQuery,
+  MapQuery,
+  MapQueryVariables,
   MapStyleName,
   MapViewConfigInput,
-  PlacedMarker,
-  SortInput,
-  Turf,
 } from "@/__generated__/types";
 import { DEFAULT_ZOOM } from "@/constants";
-import { MarkerData } from "@/types";
-import { ChoroplethLayerConfig, getChoroplethLayerConfig } from "../sources";
 import mapStyles from "../styles";
-import { MarkerQueriesResult } from "../types";
 
 export class ViewConfig implements MapViewConfigInput {
   public areaDataSourceId = "";
@@ -64,39 +56,8 @@ export const MapContext = createContext<{
   mapRef: RefObject<MapRef | null> | null;
 
   /* State */
-  boundariesPanelOpen: boolean;
-  setBoundariesPanelOpen: (open: boolean) => void;
-
   boundingBox: BoundingBoxInput | null;
   setBoundingBox: (boundingBox: BoundingBoxInput | null) => void;
-
-  editingTurf: Turf | null;
-  setEditingTurf: (turf: Turf | null) => void;
-
-  placedMarkers: PlacedMarker[];
-  placedMarkersLoading: boolean;
-  deletePlacedMarker: (id: string) => void;
-  insertPlacedMarker: (placedMarker: PlacedMarker) => void;
-  updatePlacedMarker: (placedMarker: PlacedMarker) => void;
-
-  selectedDataSourceId: string;
-  handleDataSourceSelect: (dataSourceId: string) => void;
-
-  selectedMarker: MarkerData | null;
-  setSelectedMarker: (marker: MarkerData | null) => void;
-
-  tableFilter: string;
-  setTableFilter: (filter: string) => void;
-  tablePage: number;
-  setTablePage: (page: number) => void;
-  tableSort: SortInput[];
-  setTableSort: (tableSort: SortInput[]) => void;
-
-  turfs: Turf[];
-  turfsLoading: boolean;
-  deleteTurf: (id: string) => void;
-  insertTurf: (turf: Turf) => void;
-  updateTurf: (turf: Turf) => void;
 
   viewConfig: ViewConfig;
   updateViewConfig: (config: Partial<ViewConfig>) => void;
@@ -108,60 +69,21 @@ export const MapContext = createContext<{
   setZoom: (zoom: number) => void;
 
   /* GraphQL Queries */
-  areaStatsQuery: QueryResult<AreaStatsQuery, AreaStatsQueryVariables> | null;
-  dataRecordsQuery: QueryResult<
-    DataRecordsQuery,
-    DataRecordsQueryVariables
-  > | null;
   dataSourcesQuery: QueryResult<DataSourcesQuery> | null;
-  markerQueries: MarkerQueriesResult | null;
-
-  /* Derived Properties */
-  choroplethLayerConfig: ChoroplethLayerConfig;
-  selectedRecordId: string | null;
-  setSelectedRecordId: (recordId: string | null) => void;
+  mapQuery: QueryResult<MapQuery, MapQueryVariables> | null;
 }>({
   mapId: null,
   mapName: null,
   setMapName: () => null,
   mapRef: null,
-  boundariesPanelOpen: false,
-  setBoundariesPanelOpen: () => null,
   boundingBox: null,
   setBoundingBox: () => null,
-  choroplethLayerConfig: getChoroplethLayerConfig(null, DEFAULT_ZOOM),
-  editingTurf: null,
-  setEditingTurf: () => null,
-  placedMarkers: [],
-  placedMarkersLoading: false,
-  deletePlacedMarker: () => null,
-  insertPlacedMarker: () => null,
-  updatePlacedMarker: () => null,
-  selectedMarker: null,
-  setSelectedMarker: () => null,
-  tableFilter: "",
-  setTableFilter: () => null,
-  tablePage: 0,
-  setTablePage: () => null,
-  tableSort: [],
-  setTableSort: () => null,
-  turfs: [],
-  turfsLoading: false,
-  deleteTurf: () => null,
-  insertTurf: () => null,
-  updateTurf: () => null,
   viewConfig: new ViewConfig(),
   updateViewConfig: () => null,
   viewId: null,
   setViewId: () => null,
   zoom: DEFAULT_ZOOM,
   setZoom: () => null,
-  selectedDataSourceId: "",
-  handleDataSourceSelect: () => null,
-  selectedRecordId: null,
-  setSelectedRecordId: () => null,
-  areaStatsQuery: null,
-  dataRecordsQuery: null,
   dataSourcesQuery: null,
-  markerQueries: null,
+  mapQuery: null,
 });

--- a/src/app/(private)/map/[id]/context/MarkerAndTurfContext.tsx
+++ b/src/app/(private)/map/[id]/context/MarkerAndTurfContext.tsx
@@ -1,0 +1,44 @@
+import { createContext } from "react";
+import { PlacedMarker, Turf } from "@/__generated__/types";
+import { MarkerData } from "@/types";
+import { MarkerQueriesResult } from "../types";
+
+export const MarkerAndTurfContext = createContext<{
+  /* State */
+  editingTurf: Turf | null;
+  setEditingTurf: (turf: Turf | null) => void;
+
+  placedMarkers: PlacedMarker[];
+  placedMarkersLoading: boolean;
+  deletePlacedMarker: (id: string) => void;
+  insertPlacedMarker: (placedMarker: PlacedMarker) => void;
+  updatePlacedMarker: (placedMarker: PlacedMarker) => void;
+
+  selectedMarker: MarkerData | null;
+  setSelectedMarker: (marker: MarkerData | null) => void;
+
+  turfs: Turf[];
+  turfsLoading: boolean;
+  deleteTurf: (id: string) => void;
+  insertTurf: (turf: Turf) => void;
+  updateTurf: (turf: Turf) => void;
+
+  /* GraphQL Queries */
+  markerQueries: MarkerQueriesResult | null;
+}>({
+  editingTurf: null,
+  setEditingTurf: () => null,
+  placedMarkers: [],
+  placedMarkersLoading: false,
+  deletePlacedMarker: () => null,
+  insertPlacedMarker: () => null,
+  updatePlacedMarker: () => null,
+  selectedMarker: null,
+  setSelectedMarker: () => null,
+  turfs: [],
+  turfsLoading: false,
+  deleteTurf: () => null,
+  insertTurf: () => null,
+  updateTurf: () => null,
+  markerQueries: null,
+});

--- a/src/app/(private)/map/[id]/context/TableContext.tsx
+++ b/src/app/(private)/map/[id]/context/TableContext.tsx
@@ -1,0 +1,41 @@
+import { QueryResult } from "@apollo/client";
+import { createContext } from "react";
+import {
+  DataRecordsQuery,
+  DataRecordsQueryVariables,
+  SortInput,
+} from "@/__generated__/types";
+
+export const TableContext = createContext<{
+  /* State */
+  selectedDataSourceId: string;
+  handleDataSourceSelect: (dataSourceId: string) => void;
+
+  selectedRecordId: string | null;
+  setSelectedRecordId: (recordId: string | null) => void;
+
+  tableFilter: string;
+  setTableFilter: (filter: string) => void;
+  tablePage: number;
+  setTablePage: (page: number) => void;
+  tableSort: SortInput[];
+  setTableSort: (tableSort: SortInput[]) => void;
+
+  /* GraphQL Queries */
+  dataRecordsQuery: QueryResult<
+    DataRecordsQuery,
+    DataRecordsQueryVariables
+  > | null;
+}>({
+  tableFilter: "",
+  setTableFilter: () => null,
+  tablePage: 0,
+  setTablePage: () => null,
+  tableSort: [],
+  setTableSort: () => null,
+  selectedDataSourceId: "",
+  handleDataSourceSelect: () => null,
+  selectedRecordId: null,
+  setSelectedRecordId: () => null,
+  dataRecordsQuery: null,
+});

--- a/src/app/(private)/map/[id]/hooks.ts
+++ b/src/app/(private)/map/[id]/hooks.ts
@@ -7,7 +7,7 @@ import {
   useUpsertTurfMutation,
 } from "./data";
 
-export const usePlacedMarkers = (mapId: string) => {
+export const usePlacedMarkers = (mapId: string | null) => {
   const ref = useRef<PlacedMarker[]>([]);
   const [placedMarkers, _setPlacedMarkers] = useState<PlacedMarker[]>([]);
 
@@ -28,6 +28,10 @@ export const usePlacedMarkers = (mapId: string) => {
 
   /* Complex actions */
   const deletePlacedMarker = (id: string) => {
+    if (!mapId) {
+      return;
+    }
+
     deletePlacedMarkerMutation({
       variables: {
         id,
@@ -39,6 +43,10 @@ export const usePlacedMarkers = (mapId: string) => {
   };
 
   const insertPlacedMarker = async (newMarker: PlacedMarker) => {
+    if (!mapId) {
+      return;
+    }
+
     const newMarkers = [...ref.current, newMarker];
     setPlacedMarkers(newMarkers);
 
@@ -61,6 +69,10 @@ export const usePlacedMarkers = (mapId: string) => {
   };
 
   const updatePlacedMarker = (updatedMarker: PlacedMarker) => {
+    if (!mapId) {
+      return;
+    }
+
     upsertPlacedMarkerMutation({
       variables: {
         id: updatedMarker.id,
@@ -85,7 +97,7 @@ export const usePlacedMarkers = (mapId: string) => {
   };
 };
 
-export const useTurfs = (mapId: string) => {
+export const useTurfs = (mapId: string | null) => {
   const ref = useRef<Turf[]>([]);
   const [turfs, _setTurfs] = useState<Turf[]>([]);
 
@@ -105,6 +117,10 @@ export const useTurfs = (mapId: string) => {
 
   /* Complex actions */
   const deleteTurf = (id: string) => {
+    if (!mapId) {
+      return;
+    }
+
     deleteTurfMutation({
       variables: {
         id,
@@ -116,6 +132,10 @@ export const useTurfs = (mapId: string) => {
   };
 
   const insertTurf = async (newTurf: Turf) => {
+    if (!mapId) {
+      return;
+    }
+
     const newTurfs = [...ref.current, newTurf];
     setTurfs(newTurfs);
 
@@ -138,6 +158,10 @@ export const useTurfs = (mapId: string) => {
   };
 
   const updateTurf = (updatedTurf: Turf) => {
+    if (!mapId) {
+      return;
+    }
+
     upsertTurfMutation({
       variables: {
         id: updatedTurf.id,

--- a/src/app/(private)/map/[id]/page.tsx
+++ b/src/app/(private)/map/[id]/page.tsx
@@ -1,4 +1,8 @@
 import MapPage from "./MapPage";
+import ChoroplethProvider from "./providers/ChoroplethProvider";
+import MapProvider from "./providers/MapProvider";
+import MarkerAndTurfProvider from "./providers/MarkerAndTurfProvider";
+import TableProvider from "./providers/TableProvider";
 
 export default async function MapPageWrapper({
   params,
@@ -6,5 +10,15 @@ export default async function MapPageWrapper({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  return <MapPage mapId={id} />;
+  return (
+    <MapProvider mapId={id}>
+      <ChoroplethProvider>
+        <MarkerAndTurfProvider>
+          <TableProvider>
+            <MapPage />
+          </TableProvider>
+        </MarkerAndTurfProvider>
+      </ChoroplethProvider>
+    </MapProvider>
+  );
 }

--- a/src/app/(private)/map/[id]/providers/ChoroplethProvider.tsx
+++ b/src/app/(private)/map/[id]/providers/ChoroplethProvider.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import {
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import "mapbox-gl/dist/mapbox-gl.css";
+import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { useAreaStatsQuery } from "@/app/(private)/map/[id]/data";
+import { getChoroplethLayerConfig } from "@/app/(private)/map/[id]/sources";
+import { ChoroplethContext } from "../context/ChoroplethContext";
+
+export default function ChoroplethProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { boundingBox, mapRef, viewConfig, zoom } = useContext(MapContext);
+
+  /* State */
+
+  // Keep track of area codes that have feature state, to clean if necessary
+  const areaCodesToClean = useRef<Record<string, boolean>>({});
+  // Manually keep track of fetchMore loading state as the first fetchMore
+  // doesn't trigger the query loading flag
+  const [areaStatsLoading, setAreaStatsLoading] = useState(false);
+  // Storing the last loaded source triggers re-render when Mapbox layers load
+  const [lastLoadedSourceId, setLastLoadedSourceId] = useState<
+    string | undefined
+  >();
+  const [boundariesPanelOpen, setBoundariesPanelOpen] = useState(false);
+
+  /* Derived State */
+
+  const choroplethLayerConfig = useMemo(() => {
+    return getChoroplethLayerConfig(viewConfig.areaSetGroupCode, zoom);
+  }, [viewConfig.areaSetGroupCode, zoom]);
+
+  /* GraphQL Data */
+  const areaStatsQuery = useAreaStatsQuery({
+    areaSetCode: choroplethLayerConfig.areaSetCode,
+    dataSourceId: viewConfig.areaDataSourceId,
+    column: viewConfig.areaDataColumn,
+    excludeColumns: viewConfig.getExcludeColumns(),
+    useDummyBoundingBox: choroplethLayerConfig.requiresBoundingBox,
+  });
+
+  const { data: areaStatsData, fetchMore: areaStatsFetchMore } = areaStatsQuery;
+
+  /* Effects */
+
+  /* Set Mapbox feature state on receiving new AreaStats */
+  useEffect(() => {
+    if (!areaStatsData) {
+      return;
+    }
+
+    if (mapRef?.current?.getSource(choroplethLayerConfig.mapbox.sourceId)) {
+      const nextAreaCodesToClean: Record<string, boolean> = {};
+      areaStatsData.areaStats?.stats.forEach((stat) => {
+        mapRef?.current?.setFeatureState(
+          {
+            source: choroplethLayerConfig.mapbox.sourceId,
+            sourceLayer: choroplethLayerConfig.mapbox.layerId,
+            id: stat.areaCode,
+          },
+          stat,
+        );
+        nextAreaCodesToClean[stat.areaCode] = true;
+      });
+      // Remove lingering feature states
+      for (const areaCode in Object.keys(areaCodesToClean.current)) {
+        if (!nextAreaCodesToClean[areaCode]) {
+          mapRef?.current?.removeFeatureState({
+            source: choroplethLayerConfig.mapbox.sourceId,
+            sourceLayer: choroplethLayerConfig.mapbox.layerId,
+            id: areaCode,
+          });
+        }
+      }
+      areaCodesToClean.current = nextAreaCodesToClean;
+    }
+  }, [areaStatsData, choroplethLayerConfig, lastLoadedSourceId, mapRef]);
+
+  /* Do fetchMore() (if layer needs it) when bounding box or config changes */
+  useEffect(() => {
+    if (!choroplethLayerConfig.requiresBoundingBox || !areaStatsFetchMore) {
+      return;
+    }
+    (async () => {
+      setAreaStatsLoading(true);
+      await areaStatsFetchMore({ variables: { boundingBox } });
+      setAreaStatsLoading(false);
+    })();
+  }, [areaStatsFetchMore, boundingBox, choroplethLayerConfig, viewConfig]);
+
+  return (
+    <ChoroplethContext
+      value={{
+        boundariesPanelOpen,
+        setBoundariesPanelOpen,
+
+        lastLoadedSourceId,
+        setLastLoadedSourceId,
+
+        areaStatsLoading,
+        areaStatsQuery,
+
+        choroplethLayerConfig,
+      }}
+    >
+      {children}
+    </ChoroplethContext>
+  );
+}

--- a/src/app/(private)/map/[id]/providers/MapProvider.tsx
+++ b/src/app/(private)/map/[id]/providers/MapProvider.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { ReactNode, useEffect, useRef, useState } from "react";
+import "mapbox-gl/dist/mapbox-gl.css";
+import { MapRef } from "react-map-gl/mapbox";
+import { BoundingBoxInput } from "@/__generated__/types";
+import {
+  MapContext,
+  ViewConfig,
+} from "@/app/(private)/map/[id]/context/MapContext";
+import {
+  useDataSourcesQuery,
+  useMapQuery,
+} from "@/app/(private)/map/[id]/data";
+import { DEFAULT_ZOOM } from "@/constants";
+
+export default function MapProvider({
+  children,
+  mapId,
+}: {
+  children: ReactNode;
+  mapId: string;
+}) {
+  /* Map Ref */
+  const mapRef = useRef<MapRef>(null);
+  const [mapName, setMapName] = useState<string | null>(null);
+
+  /* Map State */
+
+  const [boundingBox, setBoundingBox] = useState<BoundingBoxInput | null>(null);
+  const [viewConfig, setViewConfig] = useState(new ViewConfig());
+  const [viewId, setViewId] = useState<string | null>(null);
+  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+
+  /* GraphQL Data */
+  const dataSourcesQuery = useDataSourcesQuery();
+  const mapQuery = useMapQuery(mapId);
+
+  const updateViewConfig = (nextViewConfig: Partial<ViewConfig>) => {
+    setViewConfig(new ViewConfig({ ...viewConfig, ...nextViewConfig }));
+  };
+
+  /* Effects */
+
+  /* Update local map state when saved views are loaded from the server */
+  const { data: mapData } = mapQuery;
+
+  useEffect(() => {
+    setMapName(mapData?.map?.name || "Untitled");
+    if (mapData?.map?.views && mapData.map.views.length > 0) {
+      const nextView = mapData.map.views[0];
+      const nextViewId = nextView.id;
+      // Annoying workaround to remove __typename from read-only object (breaks `new ViewConfig()`)
+      const nextConfig = { ...nextView.config };
+      delete nextConfig.__typename;
+      setViewId(nextViewId);
+      setViewConfig(new ViewConfig(nextConfig));
+    }
+  }, [mapData]);
+
+  return (
+    <MapContext
+      value={{
+        mapId,
+        mapName,
+        setMapName,
+        mapRef,
+        boundingBox,
+        setBoundingBox,
+        viewConfig,
+        updateViewConfig,
+        viewId,
+        setViewId,
+        zoom,
+        setZoom,
+        dataSourcesQuery,
+        mapQuery,
+      }}
+    >
+      {children}
+    </MapContext>
+  );
+}

--- a/src/app/(private)/map/[id]/providers/MarkerAndTurfProvider.tsx
+++ b/src/app/(private)/map/[id]/providers/MarkerAndTurfProvider.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { ReactNode, useContext, useEffect, useState } from "react";
+import "mapbox-gl/dist/mapbox-gl.css";
+import { Turf } from "@/__generated__/types";
+import { MapContext } from "@/app/(private)/map/[id]/context/MapContext";
+import { MarkerAndTurfContext } from "@/app/(private)/map/[id]/context/MarkerAndTurfContext";
+import { useMarkerQueries } from "@/app/(private)/map/[id]/data";
+import { usePlacedMarkers, useTurfs } from "@/app/(private)/map/[id]/hooks";
+import { MarkerData } from "@/types";
+
+export default function MarkerAndTurfProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { mapId, mapQuery, viewConfig } = useContext(MapContext);
+  /* State */
+
+  const [editingTurf, setEditingTurf] = useState<Turf | null>(null);
+  const [selectedMarker, setSelectedMarker] = useState<MarkerData | null>(null);
+
+  /* GraphQL Data */
+  const markerQueries = useMarkerQueries({
+    membersDataSourceId: viewConfig.membersDataSourceId,
+    markerDataSourceIds: viewConfig.markerDataSourceIds,
+  });
+
+  /* Persisted map features */
+  const {
+    turfs,
+    setTurfs,
+    deleteTurf,
+    insertTurf,
+    updateTurf,
+    loading: turfsLoading,
+  } = useTurfs(mapId);
+
+  const {
+    placedMarkers,
+    setPlacedMarkers,
+    deletePlacedMarker,
+    insertPlacedMarker,
+    updatePlacedMarker,
+    loading: placedMarkersLoading,
+  } = usePlacedMarkers(mapId);
+
+  useEffect(() => {
+    if (mapQuery?.data?.map?.placedMarkers) {
+      setPlacedMarkers(mapQuery?.data?.map.placedMarkers);
+    }
+    if (mapQuery?.data?.map?.turfs) {
+      setTurfs(mapQuery?.data.map.turfs);
+    }
+  }, [mapQuery, setPlacedMarkers, setTurfs]);
+
+  return (
+    <MarkerAndTurfContext
+      value={{
+        editingTurf,
+        setEditingTurf,
+        placedMarkers,
+        placedMarkersLoading,
+        deletePlacedMarker,
+        insertPlacedMarker,
+        updatePlacedMarker,
+        selectedMarker,
+        setSelectedMarker,
+        turfs,
+        turfsLoading,
+        deleteTurf,
+        insertTurf,
+        updateTurf,
+        markerQueries,
+      }}
+    >
+      {children}
+    </MarkerAndTurfContext>
+  );
+}

--- a/src/app/(private)/map/[id]/providers/TableProvider.tsx
+++ b/src/app/(private)/map/[id]/providers/TableProvider.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { ReactNode, useState } from "react";
+import { SortInput } from "@/__generated__/types";
+import { TableContext } from "@/app/(private)/map/[id]/context/TableContext";
+import { useDataRecordsQuery } from "../data";
+
+const TableProvider = ({ children }: { children: ReactNode }) => {
+  const [selectedDataSourceId, setSelectedDataSourceId] = useState<string>("");
+  const [selectedRecordId, setSelectedRecordId] = useState<string | null>(null);
+
+  const [tableFilter, setTableFilter] = useState("");
+  const [tablePage, setTablePage] = useState(0);
+  const [tableSort, setTableSort] = useState<SortInput[]>([]);
+
+  const dataRecordsQuery = useDataRecordsQuery({
+    dataSourceId: selectedDataSourceId,
+    page: tablePage,
+    filter: tableFilter,
+    sort: tableSort,
+  });
+
+  const handleDataSourceSelect = (dataSourceId: string) => {
+    if (selectedDataSourceId === dataSourceId) {
+      setSelectedDataSourceId("");
+      return;
+    }
+    setSelectedDataSourceId(dataSourceId);
+  };
+
+  return (
+    <TableContext
+      value={{
+        tableFilter,
+        setTableFilter,
+        tablePage,
+        setTablePage,
+        tableSort,
+        setTableSort,
+
+        selectedDataSourceId,
+        handleDataSourceSelect,
+        selectedRecordId,
+        setSelectedRecordId,
+
+        dataRecordsQuery,
+      }}
+    >
+      {children}
+    </TableContext>
+  );
+};
+
+export default TableProvider;


### PR DESCRIPTION
The MapPage was getting pretty long and cluttered with state. This PR attempts to split up this state into separate providers, to make it easier to manage.