### PR TITLE
fix: change postgres image to ARM compativle postgis/postgis:16-3.4-a…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgis/postgis:16-3.5
+    image: postgis/postgis:16-3.4-alpine
     container_name: ts-mapped-postgres
     environment:
       POSTGRES_USER: "postgres"


### PR DESCRIPTION
Installation failed on an M-series mac; this PR addresses that issue. 

- The database import `docker compose exec -u postgres -T postgres psql < ts-mapped.psql` executed without errors, so I think this should be safe to merge.