### PR TITLE
fix: Keeping the whole polygon withing the map bounds when zooming in to selected area

### DIFF
--- a/src/app/(private)/map/[id]/components/Map.tsx
+++ b/src/app/(private)/map/[id]/components/Map.tsx
@@ -92,7 +92,6 @@ export default function Map({
     };
 
     const handleModeChange = (e: DrawModeChangeEvent) => {
-      console.log("Mode changed to", e.mode);
       setCurrentMode(e.mode);
     };
 

--- a/src/app/(private)/map/[id]/components/controls/layers/AreasControl.tsx
+++ b/src/app/(private)/map/[id]/components/controls/layers/AreasControl.tsx
@@ -107,15 +107,22 @@ const TurfItem = ({ turf }: { turf: Turf }) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleFlyTo = (turf: Turf) => {
-    // Calculate the center of the polygon using turf.js
-    const center = turfLib.center(turf.polygon);
     const map = mapRef?.current;
-    if (map) {
-      map.flyTo({
-        center: center.geometry.coordinates as [number, number],
-        zoom: 12,
-      });
-    }
+    if (!map) return;
+
+    // the bounding box of the polygon
+    const bbox = turfLib.bbox(turf.polygon);
+
+    map.fitBounds(
+      [
+        [bbox[0], bbox[1]], // southwest corner
+        [bbox[2], bbox[3]], // northeast corner
+      ],
+      {
+        padding: 100,
+        duration: 1000,
+      },
+    );
   };
 
   return (


### PR DESCRIPTION
https://linear.app/commonknowledge/issue/MAP-1064/fly-to-area-fix

Recording: https://www.loom.com/share/abc56a3eea534f13ab5988561fb56509