### PR TITLE
feat: persist public map filters when changing data source

### DIFF
--- a/src/app/(private)/map/[id]/view/[viewId]/publish/page.tsx
+++ b/src/app/(private)/map/[id]/view/[viewId]/publish/page.tsx
@@ -6,6 +6,7 @@ import DataRecordProvider from "@/components/Map/providers/DataRecordProvider";
 import DataSourcesProvider from "@/components/Map/providers/DataSourcesProvider";
 import MapProvider from "@/components/Map/providers/MapProvider";
 import MarkerAndTurfProvider from "@/components/Map/providers/MarkerAndTurfProvider";
+import PublicFiltersProvider from "@/components/PublicMap/providers/PublicFiltersProvider";
 import PublicMap from "@/components/PublicMap/PublicMap";
 import PublicMapProvider from "@/components/PublicMap/PublicMapProvider";
 import { getClient } from "@/services/apollo";
@@ -71,11 +72,13 @@ export default async function PublicMapAdminPage({
       <DataSourcesProvider>
         <DataRecordProvider>
           <PublicMapProvider publicMap={publicMap} editable>
-            <ChoroplethProvider>
-              <MarkerAndTurfProvider>
-                <PublicMap />
-              </MarkerAndTurfProvider>
-            </ChoroplethProvider>
+            <PublicFiltersProvider>
+              <ChoroplethProvider>
+                <MarkerAndTurfProvider>
+                  <PublicMap />
+                </MarkerAndTurfProvider>
+              </ChoroplethProvider>
+            </PublicFiltersProvider>
           </PublicMapProvider>
         </DataRecordProvider>
       </DataSourcesProvider>

--- a/src/app/api/graphql/context.ts
+++ b/src/app/api/graphql/context.ts
@@ -1,4 +1,4 @@
-import { CurrentUser } from "@/types";
+import { CurrentUser } from "@/authTypes";
 
 export interface GraphQLContext {
   currentUser: CurrentUser | null;

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,7 +1,7 @@
 import { verify } from "jsonwebtoken";
 import { cookies } from "next/headers";
+import { ServerSession } from "@/authTypes";
 import logger from "@/server/services/logger";
-import { ServerSession } from "@/types";
 
 export const getServerSession = async (): Promise<ServerSession> => {
   const defaultSession = { jwt: null, currentUser: null };

--- a/src/authTypes.ts
+++ b/src/authTypes.ts
@@ -1,0 +1,8 @@
+export interface CurrentUser {
+  id: string;
+}
+
+export interface ServerSession {
+  jwt: string | null;
+  currentUser: CurrentUser | null;
+}

--- a/src/components/PublicMap/PublicMapProvider.tsx
+++ b/src/components/PublicMap/PublicMapProvider.tsx
@@ -27,7 +27,9 @@ export default function PublicMapProvider({
   const [publicMap, setPublicMap] =
     useState<PublishedPublicMapQuery["publishedPublicMap"]>(initialPublicMap);
   const [searchLocation, setSearchLocation] = useState<Point | null>(null);
-  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const [activeTabId, setActiveTabId] = useState<string | null>(
+    publicMap?.dataSourceConfigs[0].dataSourceId || null,
+  );
   const [activePublishTab, setActivePublishTab] = useState<string>("settings");
   const [recordSidebarVisible, setRecordSidebarVisible] =
     useState<boolean>(false);

--- a/src/components/PublicMap/PublishedComponents/DataRecordSidebar.tsx
+++ b/src/components/PublicMap/PublishedComponents/DataRecordSidebar.tsx
@@ -10,8 +10,7 @@ import { buildName, toBoolean } from "./utils";
 
 export default function DataRecordSidebar() {
   const { selectedDataRecord } = useContext(DataRecordContext);
-  const { dataRecordsQueries, publicMap, editable } =
-    useContext(PublicMapContext);
+  const { dataRecordsQueries, publicMap } = useContext(PublicMapContext);
   const selectedDataRecordDetails = useMemo(() => {
     if (!selectedDataRecord) {
       return null;
@@ -41,12 +40,7 @@ export default function DataRecordSidebar() {
   const additionalColumns = dataSourceConfig?.additionalColumns || [];
 
   return (
-    <div
-      className={cn(
-        "flex flex-col gap-4 p-4 w-[280px] ",
-        editable ? "gap-8" : "",
-      )}
-    >
+    <div className={cn("flex flex-col gap-4 p-4 w-[280px] ")}>
       {/* Name */}
       <div className="flex flex-col gap-4">
         <div className="flex flex-col">

--- a/src/components/PublicMap/PublishedComponents/DataRecordsList.tsx
+++ b/src/components/PublicMap/PublishedComponents/DataRecordsList.tsx
@@ -42,10 +42,13 @@ export default function DataRecordsList({
 
   useEffect(() => {
     const allRecords = dataRecordsQuery?.data?.dataSource?.records || [];
-    const activeFilters = getActiveFilters(publicFilters);
+    const dataSourceId = dataRecordsQuery.data?.dataSource?.id;
+    const activeFilters = getActiveFilters(
+      dataSourceId ? publicFilters[dataSourceId] : undefined,
+    );
 
     // if no filters are selected - show all records
-    if (!publicFilters?.length || !activeFilters?.length) {
+    if (!activeFilters?.length) {
       setRecords(allRecords);
       return;
     }
@@ -53,7 +56,12 @@ export default function DataRecordsList({
     const filteredRecords = filterRecords(activeFilters, allRecords);
 
     setRecords(filteredRecords);
-  }, [publicFilters, setRecords, dataRecordsQuery?.data?.dataSource?.records]);
+  }, [
+    publicFilters,
+    setRecords,
+    dataRecordsQuery.data?.dataSource?.records,
+    dataRecordsQuery.data?.dataSource?.id,
+  ]);
 
   const dataSourceConfig = publicMap?.dataSourceConfigs.find(
     (dsc) => dsc.dataSourceId === dataRecordsQuery.data?.dataSource?.id,

--- a/src/components/PublicMap/PublishedComponents/DataSourceTabs.tsx
+++ b/src/components/PublicMap/PublishedComponents/DataSourceTabs.tsx
@@ -35,7 +35,7 @@ export default function DataSourceTabs({
   const { publicMap, activeTabId, setActiveTabId } =
     useContext(PublicMapContext);
   const { setSelectedDataRecord } = useContext(DataRecordContext);
-  const { setPublicFilters } = useContext(PublicFiltersContext);
+  const { publicFilters, setPublicFilters } = useContext(PublicFiltersContext);
 
   if (!publicMap || publicMap.dataSourceConfigs.length === 0) {
     return null;
@@ -68,7 +68,9 @@ export default function DataSourceTabs({
 
   const onTabChange = (id: string) => {
     setActiveTabId(id);
-    setPublicFilters([]); // resetting filters on tab change
+    if (!publicFilters[id]) {
+      setPublicFilters({ ...publicFilters, [id]: [] });
+    }
   };
 
   return (
@@ -132,7 +134,10 @@ function SingleDataSourceContent({
 }: SingleDataSourceContentProps) {
   const { publicFilters, setPublicFilters, records } =
     useContext(PublicFiltersContext);
-  const activeFilters = getActiveFilters(publicFilters);
+  const dataSourceId = dataRecordsQuery.data?.dataSource?.id;
+  const activeFilters = getActiveFilters(
+    dataSourceId ? publicFilters[dataSourceId] : [],
+  );
 
   const getListingsLabel = () => {
     if (!records?.length) {
@@ -143,7 +148,12 @@ function SingleDataSourceContent({
   };
 
   const resetFilters = () => {
-    setPublicFilters([]);
+    if (dataSourceId) {
+      setPublicFilters({
+        ...publicFilters,
+        [dataSourceId]: [],
+      });
+    }
   };
 
   return (

--- a/src/components/PublicMap/PublishedComponents/FiltersForm.tsx
+++ b/src/components/PublicMap/PublishedComponents/FiltersForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/shadcn/ui/dropdown-menu";
 import { Input } from "@/shadcn/ui/input";
 import { Switch } from "@/shadcn/ui/switch";
+import { PublicMapContext } from "../PublicMapContext";
 import { toBoolean } from "./utils";
 import type { FilterField, PublicFiltersFormValue } from "@/types";
 
@@ -23,13 +24,18 @@ export default function FiltersForm({
 }) {
   const [values, setValues] = useState<PublicFiltersFormValue[]>([]);
   const { publicFilters, setPublicFilters } = useContext(PublicFiltersContext);
+  const { activeTabId } = useContext(PublicMapContext);
   const { setSelectedDataRecord } = useContext(DataRecordContext);
 
   // setting default values
   useEffect(() => {
-    if (publicFilters && publicFilters?.length) {
-      setValues(publicFilters);
-
+    if (
+      publicFilters &&
+      activeTabId &&
+      publicFilters[activeTabId] &&
+      publicFilters[activeTabId].length
+    ) {
+      setValues(publicFilters[activeTabId]);
       return;
     }
 
@@ -49,7 +55,7 @@ export default function FiltersForm({
       };
     });
     setValues(defaultEmptyValues);
-  }, [fields, publicFilters]);
+  }, [activeTabId, fields, publicFilters]);
 
   const handleChange = (name: string, value: string) => {
     setValues((prev) =>
@@ -83,7 +89,9 @@ export default function FiltersForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setPublicFilters(values);
+    if (activeTabId) {
+      setPublicFilters({ ...publicFilters, [activeTabId]: values });
+    }
     // closing the data record sidebar when applying filters - to avoid showing details of a record that is filtered out
     setSelectedDataRecord(null);
     // closing filters dialog

--- a/src/components/PublicMap/PublishedComponents/FiltersList.tsx
+++ b/src/components/PublicMap/PublishedComponents/FiltersList.tsx
@@ -6,6 +6,7 @@ import { PublicMapColumnType } from "@/__generated__/types";
 import { PublicFiltersContext } from "@/components/PublicMap/context/PublicFiltersContext";
 import { Badge } from "@/shadcn/ui/badge";
 import { PublicFiltersFormValue } from "@/types";
+import { PublicMapContext } from "../PublicMapContext";
 import { getActiveFilters } from "./filtersHelpers";
 import { toBoolean } from "./utils";
 
@@ -34,28 +35,40 @@ function FiltersListBadge({
 
 export default function FiltersList() {
   const { publicFilters, setPublicFilters } = useContext(PublicFiltersContext);
-  const activeFilters = getActiveFilters(publicFilters);
+  const { activeTabId } = useContext(PublicMapContext);
+  const activeFilters = getActiveFilters(
+    activeTabId ? publicFilters[activeTabId] : undefined,
+  );
 
   const removeFilter = (filter: PublicFiltersFormValue, optionName = "") => {
+    if (!activeTabId) {
+      return;
+    }
+    const activePublicFilters = publicFilters[activeTabId] || [];
     if (optionName) {
-      setPublicFilters([
-        ...publicFilters.map((f) =>
-          f.name === filter.name
-            ? {
-                ...f,
-                selectedOptions: f.selectedOptions?.length
-                  ? [...f.selectedOptions.filter((o) => o !== optionName)]
-                  : [],
-              }
-            : { ...f },
-        ),
-      ]);
+      setPublicFilters({
+        ...publicFilters,
+        [activeTabId]: [
+          ...activePublicFilters.map((f) =>
+            f.name === filter.name
+              ? {
+                  ...f,
+                  selectedOptions: f.selectedOptions?.length
+                    ? [...f.selectedOptions.filter((o) => o !== optionName)]
+                    : [],
+                }
+              : { ...f },
+          ),
+        ],
+      });
     } else {
-      setPublicFilters([
-        ...publicFilters.map((f) =>
-          f.name === filter.name ? { ...f, value: "" } : { ...f },
-        ),
-      ]);
+      setPublicFilters({
+        [activeTabId]: [
+          ...activePublicFilters.map((f) =>
+            f.name === filter.name ? { ...f, value: "" } : { ...f },
+          ),
+        ],
+      });
     }
   };
 

--- a/src/components/PublicMap/PublishedComponents/filtersHelpers.ts
+++ b/src/components/PublicMap/PublishedComponents/filtersHelpers.ts
@@ -5,7 +5,9 @@ import {
 import { toBoolean } from "./utils";
 import type { PublicFiltersFormValue } from "@/types";
 
-export const getActiveFilters = (filters: PublicFiltersFormValue[]) => {
+export const getActiveFilters = (
+  filters: PublicFiltersFormValue[] | undefined,
+) => {
   if (!filters?.length) {
     return [];
   }

--- a/src/components/PublicMap/context/PublicFiltersContext.tsx
+++ b/src/components/PublicMap/context/PublicFiltersContext.tsx
@@ -7,10 +7,8 @@ export const PublicFiltersContext = createContext<{
   setFiltersDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
   filterFields: FilterField[];
   setFilterFields: React.Dispatch<React.SetStateAction<FilterField[]>>;
-  publicFilters: PublicFiltersFormValue[];
-  setPublicFilters: React.Dispatch<
-    React.SetStateAction<PublicFiltersFormValue[]>
-  >;
+  publicFilters: Record<string, PublicFiltersFormValue[]>;
+  setPublicFilters: (r: Record<string, PublicFiltersFormValue[]>) => void;
   records: NonNullable<PublicMapDataRecordsQuery["dataSource"]>["records"];
   setRecords: React.Dispatch<
     React.SetStateAction<
@@ -22,8 +20,8 @@ export const PublicFiltersContext = createContext<{
   setFiltersDialogOpen: () => null,
   filterFields: [],
   setFilterFields: () => [],
-  publicFilters: [],
-  setPublicFilters: () => [],
+  publicFilters: {},
+  setPublicFilters: () => null,
   records: [],
   setRecords: () => [],
 });

--- a/src/components/PublicMap/providers/PublicFiltersProvider.tsx
+++ b/src/components/PublicMap/providers/PublicFiltersProvider.tsx
@@ -16,9 +16,9 @@ export default function PublicFiltersProvider({
     useContext(PublicMapContext);
   const [filtersDialogOpen, setFiltersDialogOpen] = useState<boolean>(false);
   const [filterFields, setFilterFields] = useState<FilterField[]>([]);
-  const [publicFilters, setPublicFilters] = useState<PublicFiltersFormValue[]>(
-    [],
-  );
+  const [publicFilters, setPublicFilters] = useState<
+    Record<string, PublicFiltersFormValue[]>
+  >({});
   const [records, setRecords] = useState<
     NonNullable<PublicMapDataRecordsQuery["dataSource"]>["records"]
   >([]);

--- a/src/providers/ServerSessionProvider.tsx
+++ b/src/providers/ServerSessionProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext } from "react";
-import { ServerSession } from "@/types";
+import { ServerSession } from "@/authTypes";
 
 export const ServerSessionContext = createContext<ServerSession>({
   jwt: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,6 @@
-// Only import library types into this file
+// Only import library types and generated types into this file
 import { Geometry } from "geojson";
-
-export interface CurrentUser {
-  id: string;
-}
+import { PublicMapColumnType } from "./__generated__/types";
 
 export enum DataSourceType {
   actionnetwork = "actionnetwork",
@@ -49,11 +46,6 @@ export interface PointFeature {
   geometry: { coordinates: [number, number]; type: "Point" };
 }
 
-export interface ServerSession {
-  jwt: string | null;
-  currentUser: CurrentUser | null;
-}
-
 export interface TaggedRecord {
   externalId: string;
   json: Record<string, unknown>;
@@ -65,12 +57,6 @@ export interface TaggedRecord {
 
 export interface UploadResponseBody {
   url: string;
-}
-
-enum PublicMapColumnType {
-  Boolean = "Boolean",
-  CommaSeparatedList = "CommaSeparatedList",
-  String = "String",
 }
 
 export interface PublicFiltersFormValue {


### PR DESCRIPTION
- Persist public map filters when changing between data sources
- Fix filters on public map admin page
- Remove duplicated type defs by removing circular dependency on types.ts
- Adjust opacity of markers that don't match the filters, instead of removing them