### PR TITLE
fix: Public map sidebar info

### DIFF
--- a/src/components/PublicMap/PublishedComponents/PublicMapSidebar.tsx
+++ b/src/components/PublicMap/PublishedComponents/PublicMapSidebar.tsx
@@ -32,7 +32,7 @@ export default function PublicMapSidebar() {
   return (
     <div
       className={cn(
-        "absolute top-0 left-0 z-10 bg-white flex md:h-full md:pt-[var(--navbar-height)]"
+        "absolute top-0 left-0 z-10 bg-white flex md:h-full md:pt-[var(--navbar-height)]",
       )}
     >
       <div className="flex flex-col md:h-full md:w-[300px] border-r border-neutral-200">


### PR DESCRIPTION
1. Removing "add description" placeholder from a published map
2. Unifying the labels for map link field (it was "Add a link to your map" in the left sidebar and "Contact email" in the right sidebar - I made them both "contact email" and added "mailto:" prefix in link href - hope that's okay?).