### PR TITLE
fix: Reverse active/inactive colours on Public Map admin tabs + avoid jumping scrollbar on tabs change

### DIFF
--- a/src/components/PublicMap/EditorComponents/PublishPublicMapSidebar.tsx
+++ b/src/components/PublicMap/EditorComponents/PublishPublicMapSidebar.tsx
@@ -132,7 +132,7 @@ export default function PublishPublicMapSidebar() {
         {!hideSidebar && (
           <form onSubmit={onSubmitForm} className="flex flex-col h-full">
             <VerticalTabs
-              className="overflow-y-auto flex-1 flex flex-col"
+              className="overflow-y-hidden flex-1 flex flex-col"
               value={activePublishTab}
               onValueChange={(value) => {
                 setActivePublishTab(value);
@@ -162,7 +162,7 @@ export default function PublishPublicMapSidebar() {
                 }
               }}
             >
-              <VerticalTabsList className="flex flex-row border-b border-neutral-200 w-full">
+              <VerticalTabsList className="flex flex-row w-full">
                 <VerticalTabsTrigger
                   value="settings"
                   icon={Settings}

--- a/src/components/PublicMap/PublicMap.tsx
+++ b/src/components/PublicMap/PublicMap.tsx
@@ -33,7 +33,7 @@ export default function PublicMap() {
 
   return (
     <div
-      className="flex flex-col h-screen"
+      className="flex flex-col h-screen lg:overflow-hidden"
       style={
         showNavbar ? {} : ({ "--navbar-height": 0 } as React.CSSProperties)
       }

--- a/src/components/VerticalTabs.tsx
+++ b/src/components/VerticalTabs.tsx
@@ -87,7 +87,7 @@ export function VerticalTabsList({
   return (
     <TabsList
       className={cn(
-        "flex flex-col h-fit w-fit bg-transparent  rounded-none p-0",
+        "flex flex-col h-fit w-fit bg-transparent rounded-none p-0",
         className,
       )}
     >
@@ -106,12 +106,12 @@ export function VerticalTabsTrigger({
     <TabsTrigger
       value={value}
       className={cn(
-        "w-full  p-4 text-left border-none border-neutral-200",
-        "data-[state=active]:bg-neutral-200 data-[state=active]:text-primary",
-        "data-[state=inactive]:bg-white data-[state=inactive]:text-muted-foreground",
-        "hover:bg-muted/80 hover:text-foreground",
+        "w-full h-full p-4 text-left cursor-pointer",
+        "bg-white text-primary",
+        "data-[state=inactive]:bg-neutral-200 data-[state=inactive]:text-muted-foreground",
+        "data-[state=inactive]:hover:text-primary",
         "transition-colors duration-200",
-        "rounded-none ",
+        "rounded-none border-none shadow-none",
 
         className,
       )}
@@ -133,12 +133,12 @@ export function VerticalTabsContent({
     <TabsContent
       value={value}
       className={cn(
-        "flex-1 mt-0 p-4 bg-card text-card-foreground w-full border-r border-neutral-200 overflow-y-auto",
+        "flex-1 mt-0 p-4 bg-card text-card-foreground w-full overflow-y-auto",
         className,
       )}
     >
       {header && (
-        <div className="flex items-center gap-2 pb-3 border-b border-neutral-200">
+        <div className="flex items-center gap-2 pb-3">
           {Icon && <Icon className="size-4 flex-shrink-0" />}
           <h3 className="text-lg font-medium">{header}</h3>
         </div>


### PR DESCRIPTION
https://linear.app/commonknowledge/issue/MAP-1288/reverse-activeinactive-colours-on-public-map-admin-tabs