### PR TITLE
fix: Creating a new stacking index for main content to ensure visiblity of context popups (rendered outside of main)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default async function RootLayout({
           <TRPCReactProvider>
             <ApolloProvider ignoreAuthErrors>
               <NProgressProvider>
-                <main>
+                <main className="min-h-screen relative z-10">
                   <PublicMapPage host={host} />
                 </main>
               </NProgressProvider>
@@ -86,7 +86,7 @@ export default async function RootLayout({
             <TRPCReactProvider>
               <ApolloProvider>
                 <NProgressProvider>
-                  <main className="min-h-screen">{children}</main>
+                  <main className="min-h-screen relative z-10">{children}</main>
                   <Toaster position="top-center" />
                 </NProgressProvider>
               </ApolloProvider>


### PR DESCRIPTION
https://linear.app/commonknowledge/issue/MAP-1284/rename-view-modal-is-hidden-behind-the-navigation-bar