### PR TITLE
fix: map should be zoomed into points by default

### DIFF
--- a/src/app/map/[id]/components/Map.tsx
+++ b/src/app/map/[id]/components/Map.tsx
@@ -197,7 +197,7 @@ export default function Map({
     }
 
     const map = mapRef?.current;
-    if (!map || !ready) {
+    if (!map) {
       return;
     }
 
@@ -218,7 +218,7 @@ export default function Map({
       duration: 300,
       easing: (t) => t * (2 - t),
     });
-  }, [mapRef, ready, showControls]);
+  }, [mapRef, showControls]);
 
   return (
     <MapWrapper currentMode={pinDropMode ? "pin_drop" : currentMode}>
@@ -227,6 +227,11 @@ export default function Map({
           longitude: -4.5481,
           latitude: 54.2361,
           zoom: DEFAULT_ZOOM,
+          padding: {
+            left: CONTROL_PANEL_WIDTH,
+            top: 0,
+            bottom: 0,
+          },
         }}
         ref={mapRef}
         style={{ flexGrow: 1 }}
@@ -263,37 +268,41 @@ export default function Map({
             return;
           }
 
-          setTimeout(() => {
-            const features = placedMarkers?.length
-              ? placedMarkers.map((m) => ({
-                  type: "Feature" as const,
-                  geometry: {
-                    type: "Point" as const,
-                    coordinates: [m.point.lng, m.point.lat], // [lng, lat]
-                  },
-                  properties: {},
-                }))
-              : [];
+          // zoom into available markers by default
+          const features = placedMarkers?.length
+            ? placedMarkers.map((m) => ({
+                type: "Feature" as const,
+                geometry: {
+                  type: "Point" as const,
+                  coordinates: [m.point.lng, m.point.lat], // [lng, lat]
+                },
+                properties: {},
+              }))
+            : [];
 
-            const featureCollection: FeatureCollection<Point> = {
-              type: "FeatureCollection",
-              features,
-            };
+          const featureCollection: FeatureCollection<Point> = {
+            type: "FeatureCollection",
+            features,
+          };
 
-            const [minLng, minLat, maxLng, maxLat] =
-              turf?.bbox(featureCollection);
+          const [minLng, minLat, maxLng, maxLat] =
+            turf?.bbox(featureCollection);
 
-            map.fitBounds(
-              [
-                [minLng, minLat],
-                [maxLng, maxLat],
-              ],
-              {
-                padding: 100,
-                duration: 1000,
+          map.fitBounds(
+            [
+              [minLng, minLat],
+              [maxLng, maxLat],
+            ],
+            {
+              padding: {
+                left: CONTROL_PANEL_WIDTH + 100,
+                right: 100,
+                top: 100,
+                bottom: 100,
               },
-            );
-          }, 1000);
+              duration: 1000,
+            },
+          );
 
           toggleLabelVisibility(viewConfig.showLabels);
 

--- a/src/app/map/[id]/components/controls/PrivateMapControls.tsx
+++ b/src/app/map/[id]/components/controls/PrivateMapControls.tsx
@@ -1,5 +1,5 @@
 import { PanelLeft } from "lucide-react";
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 
 import { ChoroplethContext } from "@/app/map/[id]/context/ChoroplethContext";
 import { MapContext } from "@/app/map/[id]/context/MapContext";
@@ -12,7 +12,7 @@ import MembersControl from "./layers/MembersControl";
 import VisualiseControl from "./layers/VisualiseControl";
 
 export default function PrivateMapControls() {
-  const { ready, showControls, setShowControls } = useContext(MapContext);
+  const { showControls, setShowControls } = useContext(MapContext);
   const { setBoundariesPanelOpen } = useContext(ChoroplethContext);
 
   const onToggleControls = () => {
@@ -21,13 +21,6 @@ export default function PrivateMapControls() {
       setBoundariesPanelOpen(false);
     }
   };
-
-  // Animate show controls on component mount
-  useEffect(() => {
-    if (ready) {
-      setShowControls(true);
-    }
-  }, [ready, setShowControls]);
 
   return (
     <>

--- a/src/app/map/[id]/context/MapContext.tsx
+++ b/src/app/map/[id]/context/MapContext.tsx
@@ -138,6 +138,6 @@ export const MapContext = createContext<{
   setPinDropMode: () => null,
   ready: false,
   setReady: () => null,
-  showControls: false,
+  showControls: true,
   setShowControls: () => null,
 });

--- a/src/app/map/[id]/providers/MapProvider.tsx
+++ b/src/app/map/[id]/providers/MapProvider.tsx
@@ -42,7 +42,7 @@ export default function MapProvider({
   const [viewId, setViewId] = useState<string | null>(initialViewId || null);
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
   const [pinDropMode, setPinDropMode] = useState(false);
-  const [showControls, setShowControls] = useState(false);
+  const [showControls, setShowControls] = useState(true);
   const [ready, setReady] = useState(false);
   const [configDirty, setConfigDirty] = useState(false);
 


### PR DESCRIPTION
https://linear.app/commonknowledge/issue/MAP-1313/map-should-be-zoomed-into-points-by-default

plus setting `showControls` to `true` by default to avoid recalculating padding at mount 