### PR TITLE
fix: Sidebar menu dropdown organisations list stacking

### DIFF
--- a/src/components/SidebarUserMenu.tsx
+++ b/src/components/SidebarUserMenu.tsx
@@ -87,7 +87,7 @@ export default function SidebarUserMenu() {
                 {getOrganisation()?.name}
               </DropdownMenuSubTrigger>
               <DropdownMenuPortal>
-                <DropdownMenuSubContent>
+                <DropdownMenuSubContent className="flex flex-col">
                   {organisations.map((o) => (
                     <button
                       type="button"


### PR DESCRIPTION
https://linear.app/commonknowledge/issue/MAP-1325/list-of-organisations-should-stack-vertically-not-horizontally