### PR TITLE
Adding Sentry feedback widget to the app part of the app :)

### DIFF
--- a/src/app/(private)/layout.tsx
+++ b/src/app/(private)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getServerSession } from "@/auth";
 import { DesktopOnly } from "@/components/layout/DesktopOnly";
+import SentryFeedbackWidget from "@/components/SentryFeedbackWidget";
 import Sidebar from "@/components/Sidebar";
 import type { Metadata } from "next";
 
@@ -23,8 +24,9 @@ export default async function PrivateLayout({
     <DesktopOnly>
       <div className="flex h-screen">
         <Sidebar />
-        <div className="flex-1 overflow-auto p-10  w-full">{children}</div>
+        <div className="flex-1 overflow-auto p-10 w-full">{children}</div>
       </div>
+      <SentryFeedbackWidget />
     </DesktopOnly>
   );
 }

--- a/src/components/SentryFeedbackWidget.tsx
+++ b/src/components/SentryFeedbackWidget.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+export default function SentryFeedbackWidget() {
+  useEffect(() => {
+    Sentry.init({
+      dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+      integrations: [
+        Sentry.feedbackIntegration({
+          colorScheme: "light",
+        }),
+      ],
+    });
+  }, []);
+
+  return <></>;
+}


### PR DESCRIPTION
<img width="1512" height="795" alt="Screenshot 2025-10-07 at 11 57 13" src="https://github.com/user-attachments/assets/9b4888c1-4768-4de3-ad83-cc1c0b502a73" />
<img width="1512" height="850" alt="Screenshot 2025-10-07 at 11 57 02" src="https://github.com/user-attachments/assets/f07b7570-ad79-4cc3-be5e-bf02b4b1137c" />
<img width="1509" height="805" alt="Screenshot 2025-10-07 at 11 53 18" src="https://github.com/user-attachments/assets/0f81efd3-d7ba-4f1e-a6f4-b63368588d4f" />


The UI can be customized if needed (https://docs.sentry.io/platforms/javascript/user-feedback/configuration/) but IDK, it looks allright to me now