### PR TITLE
Refactor/remove autosave

### DIFF
--- a/src/app/map/[id]/components/Choropleth.tsx
+++ b/src/app/map/[id]/components/Choropleth.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useRef } from "react";
 import { Layer, Source } from "react-map-gl/mapbox";
 import { ChoroplethContext } from "@/app/map/[id]/context/ChoroplethContext";
-import { MapContext } from "@/app/map/[id]/context/MapContext";
+import { MapContext, getMapStyle } from "@/app/map/[id]/context/MapContext";
 import { useMapViews } from "@/app/map/[id]/hooks/useMapViews";
 import {
   CalculationType,
@@ -146,7 +146,7 @@ export default function Choropleth() {
                 "text-font": ["DIN Pro Medium", "Arial Unicode MS Bold"],
               }}
               paint={{
-                "text-color": viewConfig.getMapStyle().textColor,
+                "text-color": getMapStyle(viewConfig).textColor,
                 "text-opacity": [
                   "interpolate",
                   ["linear"],
@@ -156,7 +156,7 @@ export default function Choropleth() {
                   10,
                   0.8,
                 ],
-                "text-halo-color": viewConfig.getMapStyle().textHaloColor,
+                "text-halo-color": getMapStyle(viewConfig).textHaloColor,
                 "text-halo-width": 1.5,
               }}
             />

--- a/src/app/map/[id]/components/Map.tsx
+++ b/src/app/map/[id]/components/Map.tsx
@@ -14,7 +14,11 @@ import {
 } from "react";
 import MapGL, { NavigationControl, Popup } from "react-map-gl/mapbox";
 import { InspectorContext } from "@/app/map/[id]/context/InspectorContext";
-import { MapContext } from "@/app/map/[id]/context/MapContext";
+import {
+  MapContext,
+  getDataSourceIds,
+  getMapStyle,
+} from "@/app/map/[id]/context/MapContext";
 import { MarkerAndTurfContext } from "@/app/map/[id]/context/MarkerAndTurfContext";
 import { useMapConfig } from "@/app/map/[id]/hooks/useMapConfig";
 import { useMapViews } from "@/app/map/[id]/hooks/useMapViews";
@@ -26,7 +30,6 @@ import {
 } from "@/constants";
 import { MAPBOX_SOURCE_IDS } from "../sources";
 import { CONTROL_PANEL_WIDTH, mapColors } from "../styles";
-import { getDataSourceIds } from "../utils";
 import Choropleth from "./Choropleth";
 import FilterMarkers from "./FilterMarkers";
 
@@ -368,7 +371,7 @@ export default function Map({
         ref={mapRef}
         style={{ flexGrow: 1 }}
         mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}
-        mapStyle={`mapbox://styles/mapbox/${viewConfig.getMapStyle().slug}`}
+        mapStyle={`mapbox://styles/mapbox/${getMapStyle(viewConfig).slug}`}
         interactiveLayerIds={markerLayers}
         onClick={(e) => {
           const map = e.target;

--- a/src/app/map/[id]/components/MapViews.tsx
+++ b/src/app/map/[id]/components/MapViews.tsx
@@ -20,7 +20,10 @@ import { CSS } from "@dnd-kit/utilities";
 import { Check, Layers, Plus, X } from "lucide-react";
 import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
-import { MapContext, ViewConfig } from "@/app/map/[id]/context/MapContext";
+import {
+  MapContext,
+  createNewViewConfig,
+} from "@/app/map/[id]/context/MapContext";
 import { useMapViews } from "@/app/map/[id]/hooks/useMapViews";
 import ContextMenuContentWithFocus from "@/components/ContextMenuContentWithFocus";
 import { Button } from "@/shadcn/ui/button";
@@ -88,7 +91,7 @@ export default function MapViews() {
     const newView = {
       id: uuidv4(),
       name: newViewName.trim(),
-      config: new ViewConfig(),
+      config: createNewViewConfig(),
       dataSourceViews: [],
       mapId,
       createdAt: new Date(),

--- a/src/app/map/[id]/components/inspector/TurfMarkersList.tsx
+++ b/src/app/map/[id]/components/inspector/TurfMarkersList.tsx
@@ -1,10 +1,10 @@
 import { useQueries } from "@tanstack/react-query";
 import { useContext, useMemo } from "react";
 import { InspectorContext } from "@/app/map/[id]/context/InspectorContext";
+import { getDataSourceIds } from "@/app/map/[id]/context/MapContext";
 import { MarkerAndTurfContext } from "@/app/map/[id]/context/MarkerAndTurfContext";
 import { useDataSources } from "@/app/map/[id]/hooks/useDataSources";
 import { useMapConfig } from "@/app/map/[id]/hooks/useMapConfig";
-import { getDataSourceIds } from "@/app/map/[id]/utils";
 import DataSourceIcon from "@/components/DataSourceIcon";
 import { DataSourceRecordType } from "@/server/models/DataSource";
 import { FilterType } from "@/server/models/MapView";

--- a/src/app/map/[id]/context/MapContext.tsx
+++ b/src/app/map/[id]/context/MapContext.tsx
@@ -7,38 +7,10 @@ import {
 } from "@/server/models/MapView";
 import mapStyles from "../styles";
 import type { BoundingBox } from "@/server/models/Area";
-import type { AreaSetGroupCode } from "@/server/models/AreaSet";
-import type {
-  MapViewConfigInput,
-  VisualisationType,
-} from "@/server/models/MapView";
+import type { MapConfig } from "@/server/models/Map";
+import type { MapViewConfig } from "@/server/models/MapView";
 import type { RefObject } from "react";
 import type { MapRef } from "react-map-gl/mapbox";
-
-export class ViewConfig implements MapViewConfigInput {
-  public areaDataSourceId = "";
-  public areaDataColumn = "";
-  public areaSetGroupCode: AreaSetGroupCode | null = null;
-  public excludeColumnsString = "";
-  public mapStyleName: MapStyleName = MapStyleName.Light;
-  public showLabels = true;
-  public showBoundaryOutline = false;
-  public showMembers = true;
-  public showLocations = true;
-  public showTurf = true;
-  public calculationType?: CalculationType | null = CalculationType.Value;
-  public colorScheme?: ColorScheme | null = ColorScheme.RedBlue;
-  public reverseColorScheme?: boolean | null | undefined;
-  public visualisationType?: VisualisationType | null;
-
-  constructor(params: Partial<ViewConfig> = {}) {
-    Object.assign(this, params);
-  }
-
-  getMapStyle() {
-    return mapStyles[this.mapStyleName] || Object.values(mapStyles)[0];
-  }
-}
 
 export const MapContext = createContext<{
   /* Map ID from URL */
@@ -88,3 +60,36 @@ export const MapContext = createContext<{
   showControls: true,
   setShowControls: () => null,
 });
+
+export const createNewViewConfig = (): MapViewConfig => {
+  return {
+    areaDataSourceId: "",
+    areaDataColumn: "",
+    areaSetGroupCode: null,
+    excludeColumnsString: "",
+    mapStyleName: MapStyleName.Light,
+    showLabels: true,
+    showBoundaryOutline: false,
+    showMembers: true,
+    showLocations: true,
+    showTurf: true,
+    calculationType: CalculationType.Value,
+    colorScheme: ColorScheme.RedBlue,
+    reverseColorScheme: false,
+    visualisationType: null,
+  };
+};
+
+export const getDataSourceIds = (mapConfig: MapConfig) => {
+  return new Set(
+    [mapConfig.membersDataSourceId]
+      .concat(mapConfig.markerDataSourceIds)
+      .filter(Boolean),
+  )
+    .values()
+    .toArray();
+};
+
+export const getMapStyle = (viewConfig: MapViewConfig) => {
+  return mapStyles[viewConfig.mapStyleName] || Object.values(mapStyles)[0];
+};

--- a/src/app/map/[id]/data.ts
+++ b/src/app/map/[id]/data.ts
@@ -1,19 +1,18 @@
 import { useQuery as useTanstackQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
-
 import { CalculationType, VisualisationType } from "@/server/models/MapView";
 import { useTRPC } from "@/services/trpc/react";
-import type { ViewConfig } from "./context/MapContext";
 import type { AreaStat, BoundingBox } from "@/server/models/Area";
 import type { AreaSetCode } from "@/server/models/AreaSet";
 import type { ColumnType } from "@/server/models/DataSource";
+import type { MapViewConfig } from "@/server/models/MapView";
 
 export const useAreaStats = ({
   viewConfig,
   areaSetCode,
   boundingBox,
 }: {
-  viewConfig: ViewConfig;
+  viewConfig: MapViewConfig;
   areaSetCode: AreaSetCode;
   boundingBox?: BoundingBox | null;
 }) => {

--- a/src/app/map/[id]/hooks/useMapConfig.ts
+++ b/src/app/map/[id]/hooks/useMapConfig.ts
@@ -47,6 +47,6 @@ export function useMapConfig() {
   return {
     mapConfig,
     updateMapConfig,
-    isDirty: isPending
+    isDirty: isPending,
   };
 }

--- a/src/app/map/[id]/providers/MarkerAndTurfProvider.tsx
+++ b/src/app/map/[id]/providers/MarkerAndTurfProvider.tsx
@@ -4,13 +4,15 @@ import { useQueries } from "@tanstack/react-query";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
-import { MapContext } from "@/app/map/[id]/context/MapContext";
+import {
+  MapContext,
+  getDataSourceIds,
+} from "@/app/map/[id]/context/MapContext";
 import { MarkerAndTurfContext } from "@/app/map/[id]/context/MarkerAndTurfContext";
 import { useMapConfig } from "@/app/map/[id]/hooks/useMapConfig";
 import { useMapViews } from "@/app/map/[id]/hooks/useMapViews";
 import { useFolders, usePlacedMarkers, useTurfs } from "../hooks";
 import { useMapQuery } from "../hooks/useMapQuery";
-import { getDataSourceIds } from "../utils";
 import { PublicMapContext } from "../view/[viewIdOrHost]/publish/context/PublicMapContext";
 import type { Turf } from "@/server/models/Turf";
 import type { PointFeature } from "@/types";

--- a/src/app/map/[id]/sources.ts
+++ b/src/app/map/[id]/sources.ts
@@ -71,7 +71,7 @@ export const MAPBOX_SOURCE_IDS = Object.values(
 
 export const getChoroplethLayerConfig = (
   dataSourceAreaSetCode: AreaSetCode | null | undefined,
-  areaSetGroupCode: AreaSetGroupCode | null,
+  areaSetGroupCode: AreaSetGroupCode | null | undefined,
   zoom: number,
 ) => {
   if (areaSetGroupCode) {

--- a/src/app/map/[id]/utils.ts
+++ b/src/app/map/[id]/utils.ts
@@ -1,5 +1,3 @@
-import type { MapConfig } from "@/server/models/Map";
-
 export const sortByPositionAndId = <T extends { id: string; position: number }>(
   items: T[],
 ) => {
@@ -74,14 +72,4 @@ export const getNewPositionAfter = (
     return from + 1;
   }
   return (afterFrom + from) / 2;
-};
-
-export const getDataSourceIds = (mapConfig: MapConfig) => {
-  return new Set(
-    [mapConfig.membersDataSourceId]
-      .concat(mapConfig.markerDataSourceIds)
-      .filter(Boolean),
-  )
-    .values()
-    .toArray();
 };

--- a/src/app/map/[id]/view/[viewIdOrHost]/publish/components/DataSourcesSelect.tsx
+++ b/src/app/map/[id]/view/[viewIdOrHost]/publish/components/DataSourcesSelect.tsx
@@ -1,8 +1,8 @@
 import { Database } from "lucide-react";
 import { useContext } from "react";
+import { getDataSourceIds } from "@/app/map/[id]/context/MapContext";
 import { useDataSources } from "@/app/map/[id]/hooks/useDataSources";
 import { useMapConfig } from "@/app/map/[id]/hooks/useMapConfig";
-import { getDataSourceIds } from "@/app/map/[id]/utils";
 import { Button } from "@/shadcn/ui/button";
 import {
   DropdownMenu,

--- a/src/app/map/[id]/view/[viewIdOrHost]/publish/providers/PublicMapProvider.tsx
+++ b/src/app/map/[id]/view/[viewIdOrHost]/publish/providers/PublicMapProvider.tsx
@@ -2,10 +2,10 @@
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
+import { getDataSourceIds } from "@/app/map/[id]/context/MapContext";
 import { useDataSources } from "@/app/map/[id]/hooks/useDataSources";
 import { useMapConfig } from "@/app/map/[id]/hooks/useMapConfig";
 import { useMapViews } from "@/app/map/[id]/hooks/useMapViews";
-import { getDataSourceIds } from "@/app/map/[id]/utils";
 import { SORT_BY_LOCATION, SORT_BY_NAME_COLUMNS } from "@/constants";
 import { useTRPC } from "@/services/trpc/react";
 import { createDataSourceConfig } from "../components/DataSourcesSelect";

--- a/src/server/models/MapView.ts
+++ b/src/server/models/MapView.ts
@@ -117,7 +117,7 @@ export const mapViewConfigSchema = z.object({
   reverseColorScheme: z.boolean().nullish(),
 });
 
-export type MapViewConfigInput = z.infer<typeof mapViewConfigSchema>;
+export type MapViewConfig = z.infer<typeof mapViewConfigSchema>;
 
 export const mapViewSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
Now that we are using the `tRPC` cache as the data store for maps and views, we get optimistic updates and background sync-with-server "for free". This PR removes the auto-save `useEffect` to simplify the code somewhat.