### PR TITLE
Import regions

### DIFF
--- a/bin/cmd.ts
+++ b/bin/cmd.ts
@@ -5,6 +5,8 @@ import importConstituencies from "@/server/commands/importConstituencies";
 import importMSOAs from "@/server/commands/importMSOAs";
 import importOutputAreas from "@/server/commands/importOutputAreas";
 import importPostcodes from "@/server/commands/importPostcodes";
+import importRegions from "@/server/commands/importRegions";
+import regeocode from "@/server/commands/regeocode";
 import removeDevWebhooks from "@/server/commands/removeDevWebhooks";
 import Invite from "@/server/emails/invite";
 import enrichDataSource from "@/server/jobs/enrichDataSource";
@@ -24,7 +26,6 @@ import { getPubSub } from "@/server/services/pubsub";
 import { runWorker } from "@/server/services/queue";
 import { getClient as getRedisClient } from "@/server/services/redis";
 import { stopPublicTunnel } from "@/server/services/urls";
-import importRegions from "@/server/commands/importRegions";
 
 const program = new Command();
 
@@ -184,6 +185,14 @@ program
 
       logger.info(`Invitation token: ${token}`);
     }
+  });
+
+program
+  .command("regeocode")
+  .description("Re-geocode all data records (e.g. after adding a new area set)")
+  .option("--id <id>", "The data source ID")
+  .action(async (options) => {
+    await regeocode(options.id || null);
   });
 
 program

--- a/migrations/1764010461983_calculation_type_avg.ts
+++ b/migrations/1764010461983_calculation_type_avg.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { sql } from "kysely";
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db
+    .updateTable("map_view")
+    .set({
+      config: sql`jsonb_set(
+        config,
+        '{calculationType}',
+        '"Avg"'
+      )`,
+    })
+    .where(sql`config->>'calculationType'`, "=", "Value")
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db
+    .updateTable("map_view")
+    .set({
+      config: sql`jsonb_set(
+        config,
+        '{calculationType}',
+        '"Value"'
+      )`,
+    })
+    .where(sql`config->>'calculationType'`, "=", "Avg")
+    .execute();
+}

--- a/src/app/map/[id]/components/controls/BoundariesControl/useBoundariesControl.tsx
+++ b/src/app/map/[id]/components/controls/BoundariesControl/useBoundariesControl.tsx
@@ -115,7 +115,7 @@ export function useBoundariesControl() {
               visualisationType: VisualisationType.Choropleth,
               areaDataSourceId: voteShareDataSource.id,
               areaDataColumn: column.name,
-              calculationType: CalculationType.Value,
+              calculationType: CalculationType.Avg,
             });
           },
         }))

--- a/src/app/map/[id]/context/MapContext.tsx
+++ b/src/app/map/[id]/context/MapContext.tsx
@@ -73,7 +73,7 @@ export const createNewViewConfig = (): MapViewConfig => {
     showMembers: true,
     showLocations: true,
     showTurf: true,
-    calculationType: CalculationType.Value,
+    calculationType: CalculationType.Avg,
     colorScheme: ColorScheme.RedBlue,
     reverseColorScheme: false,
     visualisationType: null,

--- a/src/app/map/[id]/data.ts
+++ b/src/app/map/[id]/data.ts
@@ -59,7 +59,7 @@ export const useAreaStats = () => {
     trpc.area.stats.queryOptions(
       {
         areaSetCode,
-        calculationType: calculationType || CalculationType.Value,
+        calculationType: calculationType || CalculationType.Avg,
         dataSourceId,
         column: columnOrCount,
         excludeColumns,

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -18,11 +18,13 @@ export const AreaSetCodeLabels: Record<AreaSetCode, string> = {
   PC: "UK Postcode",
   OA21: "Census Output Area (2021)",
   MSOA21: "Middle Super Output Area (2021)",
+  UKR18: "UK Regions (2018)",
   WMC24: "Westminster Constituency (2024)",
 };
 
 export const AreaSetGroupCodeLabels: Record<AreaSetGroupCode, string> = {
   OA21: "Census Output Area (2021)",
+  UKR18: "UK Regions (2018)",
   WMC24: "Westminster Constituency (2024)",
 };
 

--- a/src/server/commands/importRegions.ts
+++ b/src/server/commands/importRegions.ts
@@ -10,7 +10,7 @@ import { db } from "@/server/services/database";
 import logger from "@/server/services/logger";
 import { getBaseDir } from "@/server/utils";
 
-const AREA_SET_CODE = AreaSetCode.UKREGIONCOUNTRY18;
+const AREA_SET_CODE = AreaSetCode.UKR18;
 
 const importRegions = async () => {
   const regionsGeojsonPath = join(
@@ -51,9 +51,12 @@ const importRegions = async () => {
       VALUES (
         ${name},
         ${code},
-        ST_SetSRID(
-          ST_GeomFromGeoJSON(${JSON.stringify(feature.geometry)}),
-          4326
+        ST_Transform(
+          ST_SetSRID(
+            ST_GeomFromGeoJSON(${JSON.stringify(feature.geometry)}),
+            27700  -- Set the original EPSG:27700 (British National Grid)
+          ),
+          4326  -- Convert to WGS 84
         )::geography,
         ${areaSet.id}
       )

--- a/src/server/commands/regeocode.ts
+++ b/src/server/commands/regeocode.ts
@@ -1,0 +1,45 @@
+import { geocodeRecord } from "../mapping/geocode";
+import { upsertDataRecord } from "../repositories/DataRecord";
+import { db } from "../services/database";
+import logger from "../services/logger";
+import { batch } from "../utils";
+
+const regeocode = async (dataSourceId: string | null = null) => {
+  let dataSourceQuery = db.selectFrom("dataSource").selectAll();
+  if (dataSourceId) {
+    dataSourceQuery = dataSourceQuery.where("id", "=", dataSourceId);
+  }
+  const dataSources = await dataSourceQuery.execute();
+  for (const dataSource of dataSources) {
+    const records = await db
+      .selectFrom("dataRecord")
+      .selectAll()
+      .where("dataSourceId", "=", dataSource.id)
+      .execute();
+    logger.info(
+      `Re-geocoding ${records.length} records from data source ${dataSource.name} (${dataSource.id})`,
+    );
+    const batches = batch(records, 100);
+    for (let i = 0; i < batches.length; i++) {
+      const b = batches[i];
+      await Promise.all(
+        b.map(async (r) => {
+          const geocodeResult = await geocodeRecord(
+            r,
+            dataSource.geocodingConfig,
+          );
+          await upsertDataRecord({
+            externalId: r.externalId,
+            json: r.json,
+            geocodeResult: geocodeResult,
+            geocodePoint: geocodeResult?.centralPoint,
+            dataSourceId: dataSource.id,
+          });
+        }),
+      );
+      logger.info(`Processed batch ${i + 1} of ${batches.length}`);
+    }
+  }
+};
+
+export default regeocode;

--- a/src/server/models/AreaSet.ts
+++ b/src/server/models/AreaSet.ts
@@ -5,8 +5,8 @@ export enum AreaSetCode {
   MSOA21 = "MSOA21",
   OA21 = "OA21",
   PC = "PC",
+  UKR18 = "UKR18",
   WMC24 = "WMC24",
-  UKREGIONCOUNTRY18 = "UKREGIONCOUNTRY18",
 }
 export const areaSetCodes = Object.values(AreaSetCode);
 
@@ -15,7 +15,7 @@ export const areaSetCode = z.nativeEnum(AreaSetCode);
 export enum AreaSetGroupCode {
   OA21 = "OA21",
   WMC24 = "WMC24",
-  UKREGIONCOUNTRY18 = "UKREGIONCOUNTRY18",
+  UKR18 = "UKR18",
 }
 export const areaSetGroupCodes = Object.values(AreaSetGroupCode);
 

--- a/src/server/models/MapView.ts
+++ b/src/server/models/MapView.ts
@@ -74,10 +74,9 @@ export enum VisualisationType {
 export const visualisationTypes = Object.values(VisualisationType);
 
 export enum CalculationType {
-  Value = "Value",
   Count = "Count",
   Sum = "Sum",
-  Average = "Average",
+  Avg = "Avg",
 }
 export const calculationTypes = Object.values(CalculationType);
 export const calculationType = z.nativeEnum(CalculationType);


### PR DESCRIPTION
Imports region files.

Doesn't do the rest:
- [x] Doesn't handle their choropleth usage
- [x] Doesn't add the boundaries to Mapbox or get the referent Mapbox layer ID back

Feels like long-term we'd want area sets, Mapbox IDs, choropleth and display configs, including groupings, to be database-driven rather than hardcoded, if we want to get to a system where we can smoothly load in areas on demand. But hey ho all in good time!