### PR TITLE
fix: handle % numeric values correctly

### DIFF
--- a/src/app/map/[id]/data.ts
+++ b/src/app/map/[id]/data.ts
@@ -12,7 +12,7 @@ export const useAreaStats = () => {
   const { boundingBox } = useContext(MapContext);
   const { viewConfig } = useMapViews();
   const {
-    choroplethLayerConfig: { areaSetCode },
+    choroplethLayerConfig: { areaSetCode, requiresBoundingBox },
   } = useContext(ChoroplethContext);
   const {
     calculationType,
@@ -63,7 +63,7 @@ export const useAreaStats = () => {
         dataSourceId,
         column: columnOrCount,
         excludeColumns,
-        boundingBox,
+        boundingBox: requiresBoundingBox ? boundingBox : null,
       },
       { enabled: !skipCondition },
     ),

--- a/src/server/jobs/importDataSource.ts
+++ b/src/server/jobs/importDataSource.ts
@@ -134,7 +134,9 @@ export const typeJson = (
     if (columnType === ColumnType.Object) {
       typedValue = typeJson(value as Record<string, unknown>).typedJson;
     } else if (columnType === ColumnType.Number) {
-      typedValue = Number(value);
+      typedValue = parseNumber(value);
+    } else if (columnType === ColumnType.Empty) {
+      typedValue = "";
     }
     columnDefs.push({ name: key, type: columnType });
     typedJson[key] = typedValue;
@@ -175,14 +177,28 @@ const getType = (value: unknown): ColumnType => {
   }
 
   if (typeof value === "string") {
-    const trimmedValue = value.trim();
+    const trimmedValue = value.trim().replace(/%$/, "");
     if (/^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?$/.test(trimmedValue)) {
       return ColumnType.Number;
+    }
+    if (!trimmedValue || trimmedValue === "-") {
+      return ColumnType.Empty;
     }
     return ColumnType.String;
   }
 
   return ColumnType.String;
+};
+
+/**
+ * Parse numbers according to the typing logic above:
+ * - Remove percent signs
+ */
+const parseNumber = (value: unknown): number => {
+  if (typeof value !== "string") {
+    return Number(value);
+  }
+  return Number(value.replace(/%$/, ""));
 };
 
 const addColumnDefs = (


### PR DESCRIPTION
Fixes for importing the AB Charitable Trust data.

https://linear.app/commonknowledge/issue/CONSULT-4931/handle-percent-values-correctly

- Updates the import logic to trim `%` signs from strings before testing if they are numeric
- Interprets `-` as an empty value

Also fixes a bug to prevent the map bounding box being used in the choropleth data query when not required.
