### PR TITLE
CONSULT-4972  Add search to Column selection dropdown

### DIFF
--- a/src/app/map/[id]/components/controls/VisualisationPanel/VisualisationPanel.tsx
+++ b/src/app/map/[id]/components/controls/VisualisationPanel/VisualisationPanel.tsx
@@ -18,6 +18,7 @@ import { AreaSetGroupCodeLabels } from "@/labels";
 import { ColumnType } from "@/server/models/DataSource";
 import { CalculationType, ColorScheme } from "@/server/models/MapView";
 import { Button } from "@/shadcn/ui/button";
+import { Combobox } from "@/shadcn/ui/combobox";
 import {
   Dialog,
   DialogContent,
@@ -234,34 +235,29 @@ export default function VisualisationPanel({
                 >
                   Column 1
                 </Label>
-                <Select
+                <Combobox
+                  options={[
+                    { value: NULL_UUID, label: "None" },
+                    {
+                      value: MAX_COLUMN_KEY,
+                      label: "Highest-value column (String)",
+                    },
+                    ...(dataSources
+                      ?.find((ds) => ds.id === viewConfig.areaDataSourceId)
+                      ?.columnDefs.map((col) => ({
+                        value: col.name,
+                        label: `${col.name} (${col.type})`,
+                      })) || []),
+                  ]}
                   value={viewConfig.areaDataColumn || NULL_UUID}
                   onValueChange={(value) =>
                     updateViewConfig({
                       areaDataColumn: value === NULL_UUID ? "" : value,
                     })
                   }
-                >
-                  <SelectTrigger
-                    className="w-full min-w-0"
-                    id="choropleth-column-1-select"
-                  >
-                    <SelectValue placeholder="Choose a column..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NULL_UUID}>None</SelectItem>
-                    <SelectItem key={MAX_COLUMN_KEY} value={MAX_COLUMN_KEY}>
-                      Highest-value column (String)
-                    </SelectItem>
-                    {dataSources
-                      ?.find((ds) => ds.id === viewConfig.areaDataSourceId)
-                      ?.columnDefs.map((col) => (
-                        <SelectItem key={col.name} value={col.name}>
-                          {col.name} ({col.type})
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
+                  placeholder="Choose a column..."
+                  searchPlaceholder="Search columns..."
+                />
               </>
             )}
 
@@ -276,34 +272,28 @@ export default function VisualisationPanel({
                 >
                   Column 2
                 </Label>
-                <Select
+                <Combobox
+                  options={[
+                    { value: NULL_UUID, label: "None" },
+                    ...(dataSources
+                      ?.find((ds) => ds.id === viewConfig.areaDataSourceId)
+                      ?.columnDefs.filter(
+                        (col) => col.type === ColumnType.Number,
+                      )
+                      .map((col) => ({
+                        value: col.name,
+                        label: `${col.name} (${col.type})`,
+                      })) || []),
+                  ]}
                   value={viewConfig.areaDataSecondaryColumn || NULL_UUID}
                   onValueChange={(value) =>
                     updateViewConfig({
                       areaDataSecondaryColumn: value === NULL_UUID ? "" : value,
                     })
                   }
-                >
-                  <SelectTrigger
-                    className="w-full min-w-0"
-                    id="choropleth-column-2-select"
-                  >
-                    <SelectValue placeholder="Choose a column..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NULL_UUID}>None</SelectItem>
-                    {dataSources
-                      ?.find((ds) => ds.id === viewConfig.areaDataSourceId)
-                      ?.columnDefs.filter(
-                        (col) => col.type === ColumnType.Number,
-                      )
-                      .map((col) => (
-                        <SelectItem key={col.name} value={col.name}>
-                          {col.name} ({col.type})
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
+                  placeholder="Choose a column..."
+                  searchPlaceholder="Search columns..."
+                />
               </>
             )}
 

--- a/src/shadcn/ui/combobox.tsx
+++ b/src/shadcn/ui/combobox.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Check, ChevronsUpDown } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/shadcn/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/shadcn/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shadcn/ui/popover";
+import { cn } from "@/shadcn/utils";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+}
+
+interface ComboboxProps {
+  options: ComboboxOption[];
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+}
+
+export const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
+  (
+    {
+      options = [],
+      value,
+      onValueChange,
+      placeholder = "Select an option...",
+      searchPlaceholder = "Search...",
+      emptyMessage = "No options found.",
+    },
+    ref,
+  ) => {
+    const [open, setOpen] = React.useState(false);
+
+    // Safely find selected label, with validation
+    const selectedLabel = React.useMemo(() => {
+      if (!value || !options) return undefined;
+      const selected = options.find((opt) => opt?.value === value);
+      return selected?.label;
+    }, [value, options]);
+
+    // Ensure options is always an array
+    const safeOptions = Array.isArray(options)
+      ? options.filter((opt) => opt && opt.value && opt.label)
+      : [];
+
+    const handleSelect = (currentValue: string) => {
+      if (typeof onValueChange === "function") {
+        onValueChange(currentValue === value ? "" : currentValue);
+      }
+      setOpen(false);
+    };
+
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            ref={ref}
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full justify-between"
+          >
+            <span className="truncate">{selectedLabel || placeholder}</span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-full p-0" align="start">
+          <Command>
+            <CommandInput placeholder={searchPlaceholder} />
+            <CommandList>
+              <CommandEmpty>{emptyMessage}</CommandEmpty>
+              <CommandGroup>
+                {safeOptions.length > 0
+                  ? safeOptions.map((option) => (
+                      <CommandItem
+                        key={option.value}
+                        value={option.value}
+                        onSelect={handleSelect}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            value === option.value
+                              ? "opacity-100"
+                              : "opacity-0",
+                          )}
+                        />
+                        {option.label}
+                      </CommandItem>
+                    ))
+                  : null}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    );
+  },
+);
+Combobox.displayName = "Combobox";


### PR DESCRIPTION
This pull request refactors the column selection controls in the `VisualisationPanel` to use a new searchable `Combobox` component instead of the previous `Select` dropdowns. This improves the user experience when selecting columns, especially when there are many options, by enabling search functionality and a more modern UI.

**Component Refactoring and UI Improvements:**

* Introduced a new reusable `Combobox` component in `src/shadcn/ui/combobox.tsx`, which provides a searchable and accessible dropdown for selecting options.
* Replaced the `Select` dropdowns for "Column 1" and "Column 2" in `VisualisationPanel.tsx` with the new `Combobox`, enabling search and improving usability. ([src/app/map/[id]/components/controls/VisualisationPanel/VisualisationPanel.tsxL237-R260](diffhunk://#diff-91311049c3c4fabbda815a04b1b487dbcbd8b380e1cf0a4d141338ecfda56532L237-R260), [src/app/map/[id]/components/controls/VisualisationPanel/VisualisationPanel.tsxL279-R296](diffhunk://#diff-91311049c3c4fabbda815a04b1b487dbcbd8b380e1cf0a4d141338ecfda56532L279-R296))
* Updated the import statements in `VisualisationPanel.tsx` to include the new `Combobox` component. ([src/app/map/[id]/components/controls/VisualisationPanel/VisualisationPanel.tsxR21](diffhunk://#diff-91311049c3c4fabbda815a04b1b487dbcbd8b380e1cf0a4d141338ecfda56532R21))