### PR TITLE
feat: add Baserow data source integration

### DIFF
--- a/src/app/(private)/(dashboards)/data-sources/[id]/DataSourceDashboard.tsx
+++ b/src/app/(private)/(dashboards)/data-sources/[id]/DataSourceDashboard.tsx
@@ -140,6 +140,8 @@ export function DataSourceDashboard({
     value:
       k === "type" ? (
         <DataSourceBadge type={dataSource.config[k]} />
+      ) : k === "password" ? (
+        "••••••••"
       ) : typeof dataSource.config[k as keyof typeof dataSource.config] ===
         "string" ? (
         dataSource.config[k as keyof typeof dataSource.config]

--- a/src/app/(private)/(dashboards)/data-sources/new/fields/BaserowFields.tsx
+++ b/src/app/(private)/(dashboards)/data-sources/new/fields/BaserowFields.tsx
@@ -1,0 +1,160 @@
+import FormFieldWrapper from "@/components/forms/FormFieldWrapper";
+import { BASEROW_DEFAULT_API_URL, DataSourceType } from "@/models/DataSource";
+import { Badge } from "@/shadcn/ui/badge";
+import { Input } from "@/shadcn/ui/input";
+import type { BaserowConfig } from "@/models/DataSource";
+
+export default function BaserowFields({
+  config,
+  onChange,
+}: {
+  config: Partial<BaserowConfig>;
+  onChange: (
+    config: Partial<
+      Pick<BaserowConfig, "apiUrl" | "tableId" | "email" | "password">
+    >,
+  ) => void;
+}) {
+  if (config.type !== DataSourceType.Baserow) return;
+
+  return (
+    <>
+      <FormFieldWrapper
+        label="Baserow URL"
+        id="apiUrl"
+        helpText={UrlHelpText}
+        hint="Leave as it is unless you host Baserow yourself."
+      >
+        <Input
+          type="text"
+          required
+          className="w-full"
+          id="apiUrl"
+          placeholder={BASEROW_DEFAULT_API_URL}
+          value={config.apiUrl ?? BASEROW_DEFAULT_API_URL}
+          onChange={(e) => onChange({ apiUrl: e.target.value })}
+        />
+      </FormFieldWrapper>
+      <FormFieldWrapper
+        label="Table ID"
+        id="tableId"
+        helpText={TableIdHelpText}
+        hint={
+          <>
+            The number in the URL of your table, after{" "}
+            <Badge variant="secondary">/table/</Badge>
+          </>
+        }
+      >
+        <Input
+          type="text"
+          required
+          className="w-full"
+          id="tableId"
+          value={config.tableId || ""}
+          onChange={(e) => onChange({ tableId: e.target.value })}
+        />
+      </FormFieldWrapper>
+      <FormFieldWrapper
+        label="Baserow account email"
+        id="email"
+        helpText={AccountHelpText}
+        hint="We strongly recommend creating a separate Baserow account for Mapped."
+      >
+        <Input
+          type="email"
+          required
+          className="w-full"
+          id="email"
+          value={config.email || ""}
+          onChange={(e) => onChange({ email: e.target.value })}
+        />
+      </FormFieldWrapper>
+      <FormFieldWrapper
+        label="Baserow account password"
+        id="password"
+        helpText={AccountHelpText}
+        hint="Used to sign in to Baserow on your behalf when syncing."
+      >
+        <Input
+          type="password"
+          required
+          className="w-full"
+          id="password"
+          autoComplete="new-password"
+          value={config.password || ""}
+          onChange={(e) => onChange({ password: e.target.value })}
+        />
+      </FormFieldWrapper>
+    </>
+  );
+}
+
+const UrlHelpText = (
+  <>
+    <h3>Which Baserow URL should I use?</h3>
+    <p>
+      If you use Baserow&apos;s hosted service at baserow.io, leave this as
+      https://api.baserow.io.
+    </p>
+    <p>
+      If your organisation runs its own Baserow server, enter the address of
+      that server, for example https://baserow.example.org.
+    </p>
+  </>
+);
+
+const TableIdHelpText = (
+  <>
+    <h3>How to find your Table ID in Baserow</h3>
+    <ol>
+      <li>Open your table in Baserow.</li>
+      <li>
+        Look at the address bar. The URL ends with something like
+        /database/123/table/456.
+      </li>
+      <li>
+        The number after /table/ is your Table ID. In this example it is 456.
+      </li>
+    </ol>
+  </>
+);
+
+const AccountHelpText = (
+  <>
+    <h3>Why does Mapped need a Baserow email and password?</h3>
+    <p>
+      Baserow has no &quot;connect an app&quot; flow like Google or Zetkin, and
+      its database tokens are not allowed to add columns or set up the webhooks
+      that keep your data up to date. The only way to offer those features is to
+      sign in to Baserow the same way you would.
+    </p>
+    <h3>Please create a bot account</h3>
+    <p>
+      We strongly recommend creating a new Baserow account just for Mapped —
+      often called a bot account — rather than using your own login. For
+      example, register mapped-bot@your-organisation.org and invite it to the
+      workspace containing this table.
+    </p>
+    <p>This matters because:</p>
+    <ul>
+      <li>
+        The password is stored so that background syncs keep working. Anyone who
+        obtained it would have access to every workspace that account can see,
+        so it should be able to see as little as possible.
+      </li>
+      <li>
+        A Baserow password also allows changing that account&apos;s email and
+        password. You do not want that to be your own account.
+      </li>
+      <li>
+        If the person who set up the connection leaves your organisation, or
+        changes their password, a bot account keeps your maps working.
+      </li>
+    </ul>
+    <p>
+      Invite the bot account only to the workspace it needs, and remove it when
+      you delete this data source.
+    </p>
+  </>
+);

--- a/src/app/(private)/(dashboards)/data-sources/new/page.tsx
+++ b/src/app/(private)/(dashboards)/data-sources/new/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/shadcn/ui/select";
 import ActionNetworkFields from "./fields/ActionNetworkFields";
 import AirtableFields from "./fields/AirtableFields";
+import BaserowFields from "./fields/BaserowFields";
 import CSVFields from "./fields/CSVFields";
 import GoogleSheetsFields from "./fields/GoogleSheetsFields";
 import MailchimpFields from "./fields/MailchimpFields";
@@ -280,6 +281,8 @@ function ConfigFields({
       return <ActionNetworkFields config={config} onChange={onChange} />;
     case DataSourceType.Airtable:
       return <AirtableFields config={config} onChange={onChange} />;
+    case DataSourceType.Baserow:
+      return <BaserowFields config={config} onChange={onChange} />;
     case DataSourceType.CSV:
       return <CSVFields config={config} onChange={onChange} />;
     case DataSourceType.GoogleSheets:

--- a/src/app/(private)/(dashboards)/data-sources/new/schema.ts
+++ b/src/app/(private)/(dashboards)/data-sources/new/schema.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import {
   actionNetworkConfigSchema,
   airtableConfigSchema,
+  baserowConfigSchema,
   csvConfigSchema,
   googleSheetsConfigSchema,
   mailchimpConfigSchema,
@@ -20,6 +21,7 @@ export type NewCSVConfig = z.infer<typeof newCSVConfigSchema>;
 export const newDataSourceConfigSchema = z.discriminatedUnion("type", [
   actionNetworkConfigSchema,
   airtableConfigSchema,
+  baserowConfigSchema,
   mailchimpConfigSchema,
   googleSheetsConfigSchema,
   newCSVConfigSchema,

--- a/src/app/(private)/map/[id]/components/DataSourceIcon.tsx
+++ b/src/app/(private)/map/[id]/components/DataSourceIcon.tsx
@@ -36,6 +36,7 @@ const AirtableIconSVG = () => {
 const icons: Record<DataSourceType, React.ReactNode> = {
   [DataSourceType.ActionNetwork]: <div>AN</div>,
   [DataSourceType.Airtable]: <AirtableIconSVG />,
+  [DataSourceType.Baserow]: <div>BR</div>,
   [DataSourceType.CSV]: <div>CSV</div>,
   [DataSourceType.GoogleSheets]: <div>GS</div>,
   [DataSourceType.Mailchimp]: <div>MC</div>,

--- a/src/components/DataSourceIcon.tsx
+++ b/src/components/DataSourceIcon.tsx
@@ -270,6 +270,21 @@ export const MailchimpIconSVG = () => {
   );
 };
 
+const BaserowIconSVG = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 32 32"
+    fill="none"
+  >
+    <rect width="32" height="32" rx="7" fill="#5190EF" />
+    <rect x="7" y="8" width="18" height="4" rx="1.5" fill="#FFFFFF" />
+    <rect x="7" y="14" width="18" height="4" rx="1.5" fill="#FFFFFF" />
+    <rect x="7" y="20" width="11" height="4" rx="1.5" fill="#FFFFFF" />
+  </svg>
+);
+
 const ActionNetworkSVG = () => (
   <svg
     fill="none"
@@ -319,6 +334,7 @@ const ZetkinIconSVG = () => (
 const dataSourceIcons: Record<DataSourceType, React.ReactNode> = {
   [DataSourceType.ActionNetwork]: <ActionNetworkSVG />,
   [DataSourceType.Airtable]: <AirtableIconSVG />,
+  [DataSourceType.Baserow]: <BaserowIconSVG />,
   [DataSourceType.CSV]: <File size={16} />,
   [DataSourceType.GoogleSheets]: <GoogleSheetsIconSVG />,
   [DataSourceType.Mailchimp]: <MailchimpIconSVG />,

--- a/src/features.ts
+++ b/src/features.ts
@@ -24,6 +24,13 @@ export const DataSourceFeatures: Record<
     enrichment: true,
     syncToCrm: true,
   },
+  [DataSourceType.Baserow]: {
+    autoEnrich: true,
+    autoImport: true,
+    columnDeletion: true,
+    enrichment: true,
+    syncToCrm: true,
+  },
   [DataSourceType.CSV]: {
     autoEnrich: false,
     autoImport: false,

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -10,6 +10,7 @@ import type {
   GeocodingType,
   actionNetworkConfigSchema,
   airtableConfigSchema,
+  baserowConfigSchema,
   csvConfigSchema,
   googleSheetsConfigSchema,
   mailchimpConfigSchema,
@@ -108,6 +109,7 @@ export const FilterTypeLabels: Record<
 type DataSourceConfigKey =
   | keyof z.infer<typeof actionNetworkConfigSchema>
   | keyof z.infer<typeof airtableConfigSchema>
+  | keyof z.infer<typeof baserowConfigSchema>
   | keyof z.infer<typeof googleSheetsConfigSchema>
   | keyof z.infer<typeof mailchimpConfigSchema>
   | keyof z.infer<typeof csvConfigSchema>
@@ -115,8 +117,11 @@ type DataSourceConfigKey =
 
 export const DataSourceConfigLabels: Record<DataSourceConfigKey, string> = {
   apiKey: "API Key",
+  apiUrl: "Baserow URL",
   baseId: "Base ID",
+  email: "Email",
   listId: "List ID",
+  password: "Password",
   oAuthCredentials: "OAuth Credentials",
   sheetName: "Sheet Name",
   spreadsheetId: "Spreadsheet ID",
@@ -129,6 +134,7 @@ export const DataSourceConfigLabels: Record<DataSourceConfigKey, string> = {
 export const DataSourceTypeLabels: Record<DataSourceType, string> = {
   actionnetwork: "Action Network",
   airtable: "Airtable",
+  baserow: "Baserow",
   csv: "CSV",
   googlesheets: "Google Sheets",
   mailchimp: "Mailchimp",

--- a/src/models/DataSource.ts
+++ b/src/models/DataSource.ts
@@ -23,6 +23,7 @@ export interface JobInfo {
 export enum DataSourceType {
   ActionNetwork = "actionnetwork",
   Airtable = "airtable",
+  Baserow = "baserow",
   CSV = "csv",
   GoogleSheets = "googlesheets",
   Mailchimp = "mailchimp",
@@ -46,6 +47,29 @@ export const airtableConfigSchema = z.object({
 });
 
 export type AirtableConfig = z.infer<typeof airtableConfigSchema>;
+
+export const BASEROW_DEFAULT_API_URL = "https://api.baserow.io";
+
+export const baserowConfigSchema = z.object({
+  type: z.literal(DataSourceType.Baserow),
+  // Configurable to support self-hosted Baserow instances
+  apiUrl: z
+    .string()
+    .url()
+    .refine(
+      (url) => url.startsWith("http://") || url.startsWith("https://"),
+      "Must be an http(s) URL",
+    )
+    .default(BASEROW_DEFAULT_API_URL),
+  tableId: z.string().nonempty(),
+  // Baserow has no OAuth flow, and its database tokens cannot create fields or
+  // manage webhooks, so the integration signs in as a user to obtain a JWT.
+  // Users are advised to create a dedicated bot account for this.
+  email: z.string().email(),
+  password: z.string().nonempty(),
+});
+
+export type BaserowConfig = z.infer<typeof baserowConfigSchema>;
 
 export const mailchimpConfigSchema = z.object({
   type: z.literal(DataSourceType.Mailchimp),
@@ -103,6 +127,7 @@ export type ZetkinConfig = z.infer<typeof zetkinConfigSchema>;
 export const dataSourceConfigSchema = z.discriminatedUnion("type", [
   actionNetworkConfigSchema,
   airtableConfigSchema,
+  baserowConfigSchema,
   googleSheetsConfigSchema,
   mailchimpConfigSchema,
   csvConfigSchema,

--- a/src/server/adaptors/baserow.ts
+++ b/src/server/adaptors/baserow.ts
@@ -1,0 +1,704 @@
+import z from "zod";
+import {
+  DATA_RECORDS_JOB_BATCH_SIZE,
+  ENRICHMENT_COLUMN_PREFIX,
+} from "@/constants";
+import { ColumnType } from "@/models/DataSource";
+import logger from "@/server/services/logger";
+import { getPublicUrl } from "@/server/services/urls";
+import { batch } from "@/server/utils";
+import type { DataSourceAdaptor, WebhookToggleResult } from "./abstract";
+import type { ExternalRecordUpdate } from "@/models/DataRecord";
+import type { ExternalRecord, TaggedRecord } from "@/types";
+
+// Baserow's default page size limit (BASEROW_ROW_PAGE_SIZE_LIMIT)
+const PAGE_SIZE = 200;
+
+// Baserow's default batch endpoint limit (BATCH_ROWS_SIZE_LIMIT)
+const BATCH_SIZE = 200;
+
+// Baserow access tokens expire after 10 minutes (BASEROW_ACCESS_TOKEN_LIFETIME_MINUTES).
+// Refresh a minute early to avoid racing the expiry mid-request.
+const ACCESS_TOKEN_TTL_MS = 9 * 60 * 1000;
+
+// Baserow adds these to every serialized row alongside the user's own fields
+const ROW_METADATA_KEYS = ["id", "order"];
+
+// Rows are fetched one request at a time, so cap the parallelism
+const FETCH_BY_ID_CONCURRENCY = 10;
+
+const WEBHOOK_NAME = "Mapped";
+
+const WEBHOOK_EVENTS = ["rows.created", "rows.updated", "rows.deleted"];
+
+// Field types whose values are objects wrapping the displayed value
+const UNWRAPPED_FIELD_TYPES = ["link_row", "multiple_select", "single_select"];
+
+interface BaserowField {
+  id: number;
+  name: string;
+  type: string;
+  read_only?: boolean;
+}
+
+interface Webhook {
+  id: number;
+  url: string;
+  active: boolean;
+}
+
+const TokenAuthResponse = z.object({
+  // Older Baserow versions only return `token`
+  token: z.string().optional(),
+  access_token: z.string().optional(),
+});
+
+const WebhookNotification = z.object({
+  table_id: z.number(),
+  event_type: z.string().optional(),
+  // rows.created / rows.updated
+  items: z.array(z.object({ id: z.number() })).optional(),
+  // rows.deleted
+  row_ids: z.array(z.number()).optional(),
+});
+
+export class BaserowAdaptor implements DataSourceAdaptor {
+  private dataSourceId: string;
+  private apiUrl: string;
+  private tableId: string;
+  private email: string;
+  private password: string;
+  private accessToken: string | null = null;
+  private accessTokenExpiresAt = 0;
+  private cachedFields: BaserowField[] | null = null;
+
+  constructor({
+    dataSourceId,
+    apiUrl,
+    tableId,
+    email,
+    password,
+  }: {
+    dataSourceId: string;
+    apiUrl: string;
+    tableId: string;
+    email: string;
+    password: string;
+  }) {
+    this.dataSourceId = dataSourceId;
+    this.apiUrl = apiUrl.replace(/\/+$/, "");
+    this.tableId = tableId;
+    this.email = email;
+    this.password = password;
+  }
+
+  async *extractExternalRecordIdsFromWebhookBody(
+    body: unknown,
+  ): AsyncGenerator<string> {
+    if (!body) {
+      throw new Error("Empty Baserow webhook body");
+    }
+
+    logger.debug(`Baserow webhook body: ${JSON.stringify(body)}`);
+
+    const notification = WebhookNotification.parse(body);
+    if (String(notification.table_id) !== this.tableId) {
+      logger.error(
+        `Mismatched Baserow webhook tables: Expected ${this.tableId}, got ${notification.table_id}`,
+      );
+      return;
+    }
+
+    for (const item of notification.items || []) {
+      yield String(item.id);
+    }
+
+    for (const rowId of notification.row_ids || []) {
+      yield String(rowId);
+    }
+  }
+
+  /**
+   * Baserow has no OAuth flow, and its database tokens are rejected by the
+   * field and webhook endpoints, so sign in as a user to get a JWT. Access
+   * tokens are short-lived, and refresh tokens expire after 7 days without
+   * being rotated, so there is nothing worth persisting between calls.
+   */
+  private async getAccessToken(): Promise<string> {
+    if (this.accessToken && Date.now() < this.accessTokenExpiresAt) {
+      return this.accessToken;
+    }
+
+    const response = await fetch(`${this.apiUrl}/api/user/token-auth/`, {
+      method: "POST",
+      headers: { "Content-type": "application/json" },
+      body: JSON.stringify({ email: this.email, password: this.password }),
+    });
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      throw Error(
+        `Bad Baserow token auth response: ${response.status}, ${responseText}`,
+      );
+    }
+
+    const json = TokenAuthResponse.parse(await response.json());
+    const accessToken = json.access_token || json.token;
+    if (!accessToken) {
+      throw Error("Baserow token auth response contained no access token");
+    }
+
+    this.accessToken = accessToken;
+    this.accessTokenExpiresAt = Date.now() + ACCESS_TOKEN_TTL_MS;
+
+    return accessToken;
+  }
+
+  private async request(
+    path: string,
+    init: RequestInit = {},
+    retryOnUnauthorized = true,
+  ): Promise<unknown> {
+    const token = await this.getAccessToken();
+
+    const response = await fetch(`${this.apiUrl}${path}`, {
+      ...init,
+      headers: {
+        ...init.headers,
+        Authorization: `JWT ${token}`,
+        "Content-type": "application/json",
+      },
+    });
+
+    // The token may have been invalidated server-side (e.g. a password change
+    // elsewhere, or a clock skew) before our cached expiry ran out.
+    if (response.status === 401 && retryOnUnauthorized) {
+      this.accessToken = null;
+      return this.request(path, init, false);
+    }
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      throw Error(
+        `Bad Baserow response for ${path}: ${response.status}, ${responseText}`,
+      );
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    return response.json();
+  }
+
+  async getFields(): Promise<BaserowField[]> {
+    if (this.cachedFields) {
+      return this.cachedFields;
+    }
+
+    const json = await this.request(
+      `/api/database/fields/table/${this.tableId}/`,
+    );
+    if (!Array.isArray(json)) {
+      throw Error(`Bad Baserow fields response body: ${JSON.stringify(json)}`);
+    }
+
+    const fields = json.map((f) => {
+      const field = f as BaserowField;
+      return {
+        id: field.id,
+        name: field.name,
+        type: field.type,
+        read_only: field.read_only,
+      };
+    });
+    this.cachedFields = fields;
+
+    return fields;
+  }
+
+  async getFieldNames(): Promise<string[]> {
+    const fields = await this.getFields();
+    return fields.map((field) => field.name);
+  }
+
+  /**
+   * Baserow serializes several field types as objects wrapping the value that
+   * the user actually sees in the grid:
+   *
+   * - link_row:         [{ id, value }] — value is the linked row's primary field
+   * - multiple_select:  [{ id, value, color }]
+   * - single_select:    { id, value, color }
+   *
+   * Imported as-is they become ColumnType.Object, which cannot be filtered,
+   * used as a choropleth column or geocoded, so the values are unwrapped to
+   * the strings and string arrays that Airtable already returns for the
+   * equivalent field types.
+   *
+   * The field schema is used rather than sniffing for `{ id, value }`-shaped
+   * values, so that field types added by Baserow in future are passed through
+   * untouched instead of being silently rewritten. A schema failure degrades
+   * to the raw values rather than breaking the import.
+   */
+  private async getUnwrappableFieldTypes(): Promise<Map<string, string>> {
+    const fieldTypes = new Map<string, string>();
+    try {
+      for (const field of await this.getFields()) {
+        if (UNWRAPPED_FIELD_TYPES.includes(field.type)) {
+          fieldTypes.set(field.name, field.type);
+        }
+      }
+    } catch (error) {
+      logger.warn(
+        `Could not fetch Baserow schema for wrapped fields: table ${this.tableId}`,
+        { error },
+      );
+    }
+    return fieldTypes;
+  }
+
+  /** Unwrap the field types listed above; anything that isn't shaped as
+   *  expected (including nulls, i.e. an unset single select) is kept as-is. */
+  private async unwrapFieldValues(
+    json: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const fieldTypes = await this.getUnwrappableFieldTypes();
+    if (!fieldTypes.size) {
+      return json;
+    }
+    const unwrapped = { ...json };
+    for (const [fieldName, fieldType] of fieldTypes) {
+      const value = unwrapped[fieldName];
+      if (fieldType === "single_select") {
+        unwrapped[fieldName] = unwrapValue(value);
+      } else if (Array.isArray(value)) {
+        unwrapped[fieldName] = value.map(unwrapValue);
+      }
+    }
+    return unwrapped;
+  }
+
+  private async toExternalRecord(
+    row: Record<string, unknown> | null,
+  ): Promise<ExternalRecord | null> {
+    const record = stripRowMetadata(row);
+    if (!record) {
+      return null;
+    }
+    return { ...record, json: await this.unwrapFieldValues(record.json) };
+  }
+
+  async createField(name: string, type: ColumnType): Promise<void> {
+    const body: {
+      name: string;
+      type: string;
+      description: string;
+      number_decimal_places?: number;
+      number_negative?: boolean;
+    } = {
+      name,
+      type: "text",
+      description: "Managed by Mapped",
+    };
+
+    switch (type) {
+      case ColumnType.Number:
+        body.type = "number";
+        body.number_decimal_places = 8;
+        body.number_negative = true;
+        break;
+      case ColumnType.Boolean:
+        body.type = "boolean";
+        break;
+    }
+
+    const created = (await this.request(
+      `/api/database/fields/table/${this.tableId}/`,
+      { method: "POST", body: JSON.stringify(body) },
+    )) as BaserowField;
+
+    logger.info(`Created Baserow field "${name}" (${type})`);
+
+    this.cachedFields?.push({
+      id: created.id,
+      name: created.name,
+      type: created.type,
+    });
+  }
+
+  async getRecordCount(): Promise<number | null> {
+    try {
+      const page = await this.fetchPage({ page: 1, size: 1 });
+      return page.count;
+    } catch (error) {
+      logger.warn(
+        `Could not get record count for Baserow table ${this.tableId}`,
+        { error },
+      );
+      return null;
+    }
+  }
+
+  async fetchPage({
+    page,
+    size = PAGE_SIZE,
+  }: {
+    page: number;
+    size?: number;
+  }): Promise<{ count: number; results: Record<string, unknown>[] }> {
+    const params = new URLSearchParams({
+      user_field_names: "true",
+      page: String(page),
+      size: String(size),
+    });
+
+    const json = await this.request(
+      `/api/database/rows/table/${this.tableId}/?${params}`,
+    );
+
+    if (
+      !json ||
+      typeof json !== "object" ||
+      !("results" in json) ||
+      !Array.isArray(json.results)
+    ) {
+      throw Error(`Bad Baserow rows response body: ${JSON.stringify(json)}`);
+    }
+
+    return {
+      count: "count" in json ? Number(json.count) : json.results.length,
+      results: json.results as Record<string, unknown>[],
+    };
+  }
+
+  async *fetchAll(): AsyncGenerator<ExternalRecord> {
+    let page = 1;
+    let fetched = 0;
+    let count = 0;
+
+    do {
+      const pageData = await this.fetchPage({ page });
+      count = pageData.count;
+      fetched += pageData.results.length;
+
+      if (!pageData.results.length) {
+        return;
+      }
+
+      for (const row of pageData.results) {
+        const record = await this.toExternalRecord(row);
+        // Baserow creates empty placeholder rows with every new table
+        if (record && !isEmptyRecord(record.json)) {
+          yield record;
+        }
+      }
+
+      page++;
+    } while (fetched < count);
+  }
+
+  async fetchFirst(): Promise<ExternalRecord | null> {
+    try {
+      const pageData = await this.fetchPage({ page: 1 });
+      for (const row of pageData.results) {
+        const record = await this.toExternalRecord(row);
+        // Return the first non-empty row
+        if (record && !isEmptyRecord(record.json)) {
+          return record;
+        }
+      }
+    } catch (error) {
+      logger.warn(
+        `Could not get first record for Baserow table ${this.tableId}`,
+        { error },
+      );
+    }
+    return null;
+  }
+
+  /**
+   * Baserow cannot filter rows by id, so each row is fetched individually.
+   */
+  async fetchByExternalId(externalIds: string[]): Promise<ExternalRecord[]> {
+    if (externalIds.length > DATA_RECORDS_JOB_BATCH_SIZE) {
+      // If this error happens it means jobs that fetch data by record ID
+      // are too large and should be split into smaller batches
+      throw new Error("Cannot fetch more than 100 records at once.");
+    }
+
+    const records: ExternalRecord[] = [];
+
+    for (const idBatch of batch(externalIds, FETCH_BY_ID_CONCURRENCY)) {
+      const batchRecords = await Promise.all(
+        idBatch.map((externalId) => this.fetchRow(externalId)),
+      );
+      for (const record of batchRecords) {
+        if (record) {
+          records.push(record);
+        }
+      }
+    }
+
+    return records;
+  }
+
+  private async fetchRow(externalId: string): Promise<ExternalRecord | null> {
+    try {
+      const json = await this.request(
+        `/api/database/rows/table/${this.tableId}/${externalId}/?user_field_names=true`,
+      );
+      return await this.toExternalRecord(json as Record<string, unknown>);
+    } catch (error) {
+      // The row may have been deleted between the webhook and this fetch
+      logger.warn(
+        `Could not fetch Baserow row ${externalId} in table ${this.tableId}`,
+        { error },
+      );
+      return null;
+    }
+  }
+
+  async listWebhooks(urlContains: string): Promise<Webhook[]> {
+    const json = await this.request(
+      `/api/database/webhooks/table/${this.tableId}/`,
+    );
+
+    if (!Array.isArray(json)) {
+      throw Error(
+        `Bad Baserow webhooks response body: ${JSON.stringify(json)}`,
+      );
+    }
+
+    return json
+      .map((w) => w as Webhook)
+      .filter((webhook) => webhook.url.includes(urlContains));
+  }
+
+  async removeDevWebhooks(): Promise<void> {
+    const webhooks = await this.listWebhooks("ngrok");
+    await this.removeWebhooks(webhooks);
+  }
+
+  async toggleWebhook(enable: boolean): Promise<WebhookToggleResult> {
+    const publicUrl = await getPublicUrl();
+    const webhooks = await this.listWebhooks(publicUrl);
+    const oldWebhookIds = webhooks.map((webhook) => String(webhook.id));
+
+    // Remove webhooks on user request
+    if (!enable) {
+      logger.info(
+        `Removing Baserow webhooks for data source ${this.dataSourceId}`,
+      );
+      await this.removeWebhooks(webhooks);
+      return {
+        action: oldWebhookIds.length ? "removed" : "noop",
+        oldWebhookIds,
+        newWebhookIds: [],
+      };
+    }
+
+    // Baserow webhooks do not expire, but they are deactivated after repeated
+    // delivery failures, so only keep one that is still active.
+    if (webhooks.length === 1 && webhooks[0].active) {
+      logger.info(
+        `Baserow webhook exists for data source ${this.dataSourceId}`,
+      );
+      return {
+        action: "kept",
+        oldWebhookIds: [],
+        newWebhookIds: [String(webhooks[0].id)],
+      };
+    }
+
+    // Cleanup deactivated or duplicate webhooks
+    await this.removeWebhooks(webhooks);
+
+    const notificationUrl = await getPublicUrl(
+      `/api/data-sources/${this.dataSourceId}/webhook`,
+    );
+
+    logger.info(
+      `Baserow notification URL for data source ${this.dataSourceId}: ${notificationUrl}`,
+    );
+
+    const created = (await this.request(
+      `/api/database/webhooks/table/${this.tableId}/`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: WEBHOOK_NAME,
+          url: notificationUrl,
+          request_method: "POST",
+          include_all_events: false,
+          events: WEBHOOK_EVENTS,
+          headers: {},
+          use_user_field_names: true,
+        }),
+      },
+    )) as { id: number };
+
+    return {
+      action: oldWebhookIds.length ? "recreated" : "created",
+      oldWebhookIds,
+      newWebhookIds: created.id ? [String(created.id)] : [],
+    };
+  }
+
+  async removeWebhooks(webhooks: Webhook[]): Promise<void> {
+    for (const webhook of webhooks) {
+      logger.info(
+        `Removing Baserow webhook for data source ${this.dataSourceId}: ${webhook.id}`,
+      );
+      await this.request(`/api/database/webhooks/${webhook.id}/`, {
+        method: "DELETE",
+      });
+    }
+  }
+
+  async updateRecords(recordUpdates: ExternalRecordUpdate[]): Promise<void> {
+    if (!recordUpdates.length) {
+      return;
+    }
+
+    // Map used here to be able to remove the existing fields below
+    const newFields = new Map<string, ColumnType>();
+    for (const record of recordUpdates) {
+      for (const column of record.columns) {
+        newFields.set(column.def.name, column.def.type);
+      }
+    }
+
+    const existingFields = await this.getFieldNames();
+    for (const fieldName of existingFields) {
+      newFields.delete(fieldName);
+    }
+
+    for (const [field, type] of newFields) {
+      await this.createField(field, type);
+    }
+
+    for (const recordBatch of batch(recordUpdates, BATCH_SIZE)) {
+      const items = recordBatch.map((record) => {
+        const fields: Record<string, unknown> = {};
+        for (const column of record.columns) {
+          fields[column.def.name] = column.value;
+        }
+        return { id: Number(record.externalRecord.externalId), ...fields };
+      });
+
+      await this.batchUpdateRows(items);
+    }
+  }
+
+  async tagRecords(taggedRecords: TaggedRecord[]): Promise<void> {
+    if (!taggedRecords.length) {
+      return;
+    }
+
+    // Assume same tag applied to all records
+    const fieldName = taggedRecords[0].tag.name;
+
+    const existingFields = await this.getFieldNames();
+    logger.debug(
+      `Baserow tagRecords: field="${fieldName}", existingFields=${JSON.stringify(existingFields)}`,
+    );
+    if (!existingFields.includes(fieldName)) {
+      logger.info(`Creating new Baserow field: "${fieldName}"`);
+      await this.createField(fieldName, ColumnType.Boolean);
+    } else {
+      logger.info(
+        `Baserow field "${fieldName}" already exists, skipping creation`,
+      );
+    }
+
+    for (const recordBatch of batch(taggedRecords, BATCH_SIZE)) {
+      const items = recordBatch.map((record) => ({
+        id: Number(record.externalId),
+        [fieldName]: record.tag.present,
+      }));
+
+      logger.debug(
+        `Baserow batch update ${items.length} records for field "${fieldName}"`,
+      );
+      await this.batchUpdateRows(items);
+    }
+  }
+
+  private async batchUpdateRows(
+    items: Record<string, unknown>[],
+  ): Promise<void> {
+    await this.request(
+      `/api/database/rows/table/${this.tableId}/batch/?user_field_names=true`,
+      { method: "PATCH", body: JSON.stringify({ items }) },
+    );
+  }
+
+  async deleteColumn(columnName: string): Promise<void> {
+    if (!columnName.startsWith(ENRICHMENT_COLUMN_PREFIX)) {
+      throw new Error(
+        `Refusing to delete column "${columnName}": only enrichment columns (prefixed with "${ENRICHMENT_COLUMN_PREFIX}") can be deleted.`,
+      );
+    }
+
+    const fields = await this.getFields();
+    const field = fields.find((f) => f.name === columnName);
+    if (!field) {
+      logger.warn(
+        `Baserow field "${columnName}" not found in table ${this.tableId}, skipping deletion`,
+      );
+      return;
+    }
+
+    await this.request(`/api/database/fields/${field.id}/`, {
+      method: "DELETE",
+    });
+
+    this.cachedFields =
+      this.cachedFields?.filter((f) => f.id !== field.id) || null;
+  }
+}
+
+const unwrapValue = (value: unknown) =>
+  value && typeof value === "object" && "value" in value
+    ? (value as { value: unknown }).value
+    : value;
+
+const stripRowMetadata = (
+  row: Record<string, unknown> | null,
+): ExternalRecord | null => {
+  if (!row || typeof row !== "object" || !("id" in row)) {
+    return null;
+  }
+
+  const json: Record<string, unknown> = {};
+  for (const key of Object.keys(row)) {
+    if (!ROW_METADATA_KEYS.includes(key)) {
+      json[key] = row[key];
+    }
+  }
+
+  return { externalId: String(row.id), json };
+};
+
+// Baserow populates new tables with empty placeholder rows, which look like
+// `{ "Name": "", "Notes": null, "Active": false }`.
+const isEmptyRecord = (o: Record<string, unknown>) => {
+  for (const k of Object.keys(o)) {
+    const value = o[k];
+    if (Array.isArray(value)) {
+      if (value.length) {
+        return false;
+      }
+      continue;
+    }
+    if (
+      value !== null &&
+      value !== undefined &&
+      value !== "" &&
+      value !== false
+    ) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/src/server/adaptors/baserow.ts
+++ b/src/server/adaptors/baserow.ts
@@ -31,8 +31,19 @@ const WEBHOOK_NAME = "Mapped";
 
 const WEBHOOK_EVENTS = ["rows.created", "rows.updated", "rows.deleted"];
 
-// Field types whose values are objects wrapping the displayed value
-const UNWRAPPED_FIELD_TYPES = ["link_row", "multiple_select", "single_select"];
+// Field types whose values are objects wrapping the displayed value, and the
+// property each one wraps it in
+const UNWRAPPED_FIELD_TYPES: Record<
+  string,
+  { key: "value" | "name"; array: boolean }
+> = {
+  link_row: { key: "value", array: true },
+  multiple_select: { key: "value", array: true },
+  single_select: { key: "value", array: false },
+  multiple_collaborators: { key: "name", array: true },
+  created_by: { key: "name", array: false },
+  last_modified_by: { key: "name", array: false },
+};
 
 interface BaserowField {
   id: number;
@@ -226,26 +237,33 @@ export class BaserowAdaptor implements DataSourceAdaptor {
    * Baserow serializes several field types as objects wrapping the value that
    * the user actually sees in the grid:
    *
-   * - link_row:         [{ id, value }] — value is the linked row's primary field
-   * - multiple_select:  [{ id, value, color }]
-   * - single_select:    { id, value, color }
+   * - link_row:               [{ id, value }] — the linked row's primary field
+   * - multiple_select:        [{ id, value, color }]
+   * - single_select:          { id, value, color }
+   * - multiple_collaborators: [{ id, name }]
+   * - created_by:             { id, name }
+   * - last_modified_by:       { id, name }
    *
    * Imported as-is they become ColumnType.Object, which cannot be filtered,
    * used as a choropleth column or geocoded, so the values are unwrapped to
    * the strings and string arrays that Airtable already returns for the
-   * equivalent field types.
+   * equivalent field types. Note that the wrapping property is `value` for
+   * some types and `name` for the user-valued ones.
    *
-   * The field schema is used rather than sniffing for `{ id, value }`-shaped
+   * The field schema is used rather than sniffing for `{ id, ... }`-shaped
    * values, so that field types added by Baserow in future are passed through
    * untouched instead of being silently rewritten. A schema failure degrades
    * to the raw values rather than breaking the import.
    */
-  private async getUnwrappableFieldTypes(): Promise<Map<string, string>> {
-    const fieldTypes = new Map<string, string>();
+  private async getUnwrappableFields(): Promise<
+    Map<string, (typeof UNWRAPPED_FIELD_TYPES)[string]>
+  > {
+    const fields = new Map<string, (typeof UNWRAPPED_FIELD_TYPES)[string]>();
     try {
       for (const field of await this.getFields()) {
-        if (UNWRAPPED_FIELD_TYPES.includes(field.type)) {
-          fieldTypes.set(field.name, field.type);
+        const unwrap = UNWRAPPED_FIELD_TYPES[field.type];
+        if (unwrap) {
+          fields.set(field.name, unwrap);
         }
       }
     } catch (error) {
@@ -254,7 +272,7 @@ export class BaserowAdaptor implements DataSourceAdaptor {
         { error },
       );
     }
-    return fieldTypes;
+    return fields;
   }
 
   /** Unwrap the field types listed above; anything that isn't shaped as
@@ -262,17 +280,17 @@ export class BaserowAdaptor implements DataSourceAdaptor {
   private async unwrapFieldValues(
     json: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
-    const fieldTypes = await this.getUnwrappableFieldTypes();
-    if (!fieldTypes.size) {
+    const fields = await this.getUnwrappableFields();
+    if (!fields.size) {
       return json;
     }
     const unwrapped = { ...json };
-    for (const [fieldName, fieldType] of fieldTypes) {
+    for (const [fieldName, { key, array }] of fields) {
       const value = unwrapped[fieldName];
-      if (fieldType === "single_select") {
-        unwrapped[fieldName] = unwrapValue(value);
+      if (!array) {
+        unwrapped[fieldName] = unwrapValue(value, key);
       } else if (Array.isArray(value)) {
-        unwrapped[fieldName] = value.map(unwrapValue);
+        unwrapped[fieldName] = value.map((item) => unwrapValue(item, key));
       }
     }
     return unwrapped;
@@ -658,9 +676,9 @@ export class BaserowAdaptor implements DataSourceAdaptor {
   }
 }
 
-const unwrapValue = (value: unknown) =>
-  value && typeof value === "object" && "value" in value
-    ? (value as { value: unknown }).value
+const unwrapValue = (value: unknown, key: "value" | "name") =>
+  value && typeof value === "object" && key in value
+    ? (value as Record<string, unknown>)[key]
     : value;
 
 const stripRowMetadata = (

--- a/src/server/adaptors/index.ts
+++ b/src/server/adaptors/index.ts
@@ -2,6 +2,7 @@ import { DataSourceType } from "@/models/DataSource";
 import logger from "@/server/services/logger";
 import { ActionNetworkAdaptor } from "./actionnetwork";
 import { AirtableAdaptor } from "./airtable";
+import { BaserowAdaptor } from "./baserow";
 import { CSVAdaptor } from "./csv";
 import { GoogleSheetsAdaptor } from "./googlesheets";
 import { MailchimpAdaptor } from "./mailchimp";
@@ -25,6 +26,14 @@ export const getDataSourceAdaptor = (dataSource: {
         config.baseId,
         config.tableId,
       );
+    case DataSourceType.Baserow:
+      return new BaserowAdaptor({
+        dataSourceId: id,
+        apiUrl: config.apiUrl,
+        tableId: config.tableId,
+        email: config.email,
+        password: config.password,
+      });
     case DataSourceType.CSV:
       return new CSVAdaptor(config.url);
     case DataSourceType.GoogleSheets:

--- a/src/server/jobs/refreshWebhooks.ts
+++ b/src/server/jobs/refreshWebhooks.ts
@@ -2,9 +2,11 @@ import { v4 as uuidv4 } from "uuid";
 import {
   DataSourceType,
   airtableConfigSchema,
+  baserowConfigSchema,
   googleSheetsConfigSchema,
 } from "@/models/DataSource";
 import { AirtableAdaptor } from "@/server/adaptors/airtable";
+import { BaserowAdaptor } from "@/server/adaptors/baserow";
 import { GoogleSheetsAdaptor } from "@/server/adaptors/googlesheets";
 import {
   findDataSourceById,
@@ -96,6 +98,52 @@ const refreshWebhooks = async (args: object | null): Promise<boolean> => {
         runId,
         dataSourceId: source.id,
         dataSourceType: DataSourceType.Airtable,
+        enabled: enable,
+        error,
+      });
+      continue;
+    }
+  }
+
+  const baserowDataSources = await findDataSourcesByType(
+    DataSourceType.Baserow,
+  );
+  for (const source of baserowDataSources) {
+    const result = baserowConfigSchema.safeParse(source.config);
+    if (!result.success) {
+      logger.warn(
+        `Failed to parse Baserow config for data source ${source.id}`,
+        { error: result.error },
+      );
+      continue;
+    }
+    const config = result.data;
+    const adaptor = new BaserowAdaptor({
+      dataSourceId: source.id,
+      apiUrl: config.apiUrl,
+      tableId: config.tableId,
+      email: config.email,
+      password: config.password,
+    });
+    const enable = source.autoEnrich || source.autoImport;
+    try {
+      const toggleResult = await adaptor.toggleWebhook(enable);
+      await logRefresh({
+        runId,
+        dataSourceId: source.id,
+        dataSourceType: DataSourceType.Baserow,
+        enabled: enable,
+        result: toggleResult,
+      });
+    } catch (error) {
+      logger.warn(
+        `Failed to refresh Baserow webhook for data source ${source.id}`,
+        { error },
+      );
+      await logRefresh({
+        runId,
+        dataSourceId: source.id,
+        dataSourceType: DataSourceType.Baserow,
         enabled: enable,
         error,
       });

--- a/tests/unit/server/adaptors/baserow.test.ts
+++ b/tests/unit/server/adaptors/baserow.test.ts
@@ -18,6 +18,9 @@ import { getPublicUrl } from "@/server/services/urls";
  *   left unset for "Onson Sweemy"
  * - a "Tags" multiple select field, set to "Red" and "Blue" for
  *   "Sleve McDichael" and left empty for "Onson Sweemy"
+ * - a "Collaborators" multiple collaborators field, listing exactly the
+ *   credentials' own user on "Sleve McDichael" and empty on "Onson Sweemy"
+ * - a "Created By" field (read-only, populated by Baserow)
  *
  * The tests create and delete their own "Mapped: ..." columns and webhooks.
  */
@@ -148,6 +151,25 @@ describe("Baserow adaptor tests", () => {
     const [record] = await adaptor.fetchByExternalId(["2"]);
     expect(record.json["Status"]).toBeNull();
     expect(record.json["Tags"]).toEqual([]);
+  });
+
+  // Collaborator and created_by fields wrap their value in `name` rather than
+  // `value`, so they need unwrapping too
+  test("unwraps collaborator and created_by fields", async () => {
+    const adaptor = getAdaptor();
+    const [record] = await adaptor.fetchByExternalId(["1"]);
+
+    // Asserted by shape rather than by name, so the test survives the
+    // credentials being pointed at a different account
+    expect(typeof record.json["Created By"]).toBe("string");
+    expect(record.json["Created By"]).not.toBe("");
+    expect(record.json["Collaborators"]).toEqual([record.json["Created By"]]);
+  });
+
+  test("leaves an empty collaborator field empty", async () => {
+    const adaptor = getAdaptor();
+    const [record] = await adaptor.fetchByExternalId(["2"]);
+    expect(record.json["Collaborators"]).toEqual([]);
   });
 
   test("fetchByExternalId skips deleted rows", async () => {

--- a/tests/unit/server/adaptors/baserow.test.ts
+++ b/tests/unit/server/adaptors/baserow.test.ts
@@ -1,0 +1,295 @@
+import { afterAll, describe, expect, inject, test } from "vitest";
+import { ENRICHMENT_COLUMN_PREFIX } from "@/constants";
+import { ColumnType } from "@/models/DataSource";
+import { BaserowAdaptor } from "@/server/adaptors/baserow";
+import { getPublicUrl } from "@/server/services/urls";
+
+/**
+ * These tests run against the real Baserow API, using the `baserow` entry in
+ * test_credentials.json. The table it points at must contain:
+ *
+ * - a "Name" text field, with rows "Sleve McDichael" (id 1) and
+ *   "Onson Sweemy" (id 2)
+ * - an "Unused" field that is empty in every row
+ * - a "Link" link-to-table field, pointing at a second table whose primary
+ *   field holds "Matthew", "Mark", "Luke" and "John". "Sleve McDichael" links
+ *   to Mark and Luke; "Onson Sweemy" links to John.
+ * - a "Status" single select field, set to "Active" for "Sleve McDichael" and
+ *   left unset for "Onson Sweemy"
+ * - a "Tags" multiple select field, set to "Red" and "Blue" for
+ *   "Sleve McDichael" and left empty for "Onson Sweemy"
+ *
+ * The tests create and delete their own "Mapped: ..." columns and webhooks.
+ */
+const credentials = inject("credentials");
+
+const TAG_COLUMN = `${ENRICHMENT_COLUMN_PREFIX}Test Tag`;
+const ENRICHMENT_COLUMN = `${ENRICHMENT_COLUMN_PREFIX}Test Column`;
+
+const sorted = (value: unknown) =>
+  Array.isArray(value) ? [...value].sort() : value;
+
+const getAdaptor = () =>
+  new BaserowAdaptor({
+    dataSourceId: "test-data-source",
+    apiUrl: credentials.baserow.apiUrl,
+    tableId: credentials.baserow.tableId,
+    email: credentials.baserow.email,
+    password: credentials.baserow.password,
+  });
+
+describe("Baserow adaptor tests", () => {
+  afterAll(async () => {
+    // Columns and webhooks are created against a shared table, so leaving them
+    // behind would change the result of the next run.
+    const adaptor = getAdaptor();
+    for (const column of [TAG_COLUMN, ENRICHMENT_COLUMN]) {
+      try {
+        await adaptor.deleteColumn(column);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    try {
+      await adaptor.toggleWebhook(false);
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  test("Connection succeeds", async () => {
+    const adaptor = getAdaptor();
+    const firstRow = await adaptor.fetchFirst();
+    expect(firstRow).toHaveProperty("externalId");
+    // "Unused" is empty in every row, so it is only present if columns with no
+    // values survive the import
+    expect(firstRow?.json).toHaveProperty("Unused");
+    expect(firstRow?.json["Name"]).toBe("Sleve McDichael");
+  });
+
+  test("fetchFirst strips Baserow row metadata", async () => {
+    const adaptor = getAdaptor();
+    const firstRow = await adaptor.fetchFirst();
+    expect(firstRow?.json).not.toHaveProperty("id");
+    expect(firstRow?.json).not.toHaveProperty("order");
+  });
+
+  test("getFields returns fields", async () => {
+    const adaptor = getAdaptor();
+    const fields = await adaptor.getFields();
+    expect(Array.isArray(fields)).toBe(true);
+    expect(fields.length).toBeGreaterThan(0);
+    expect(fields.map((field) => field.name)).toContain("Name");
+  });
+
+  test("getRecordCount returns the number of rows", async () => {
+    const adaptor = getAdaptor();
+    const count = await adaptor.getRecordCount();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("fetchAll yields records", async () => {
+    const adaptor = getAdaptor();
+    const results = [];
+    for await (const rec of adaptor.fetchAll()) {
+      results.push(rec);
+    }
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]).toHaveProperty("externalId");
+  });
+
+  test("fetchPage returns page data", async () => {
+    const adaptor = getAdaptor();
+    const result = await adaptor.fetchPage({ page: 1 });
+    expect(result).toHaveProperty("results");
+    expect(result.count).toBeGreaterThan(0);
+  });
+
+  test("fetchByExternalId returns records", async () => {
+    const adaptor = getAdaptor();
+    const firstRow = await adaptor.fetchFirst();
+    if (!firstRow) throw new Error("No records in table");
+    const result = await adaptor.fetchByExternalId([firstRow.externalId]);
+    expect(result[0]).toHaveProperty("externalId", firstRow.externalId);
+  });
+
+  // Link fields must come through as the linked rows' primary field values,
+  // not as Baserow's `{ id, value }` objects
+  test("resolves linked rows when fetching by external id", async () => {
+    const adaptor = getAdaptor();
+    // "Sleve McDichael", linked to two rows: Mark and Luke
+    const records = await adaptor.fetchByExternalId(["1"]);
+    expect(records).toHaveLength(1);
+    // Sorted because the order depends on how the links were added in Baserow
+    expect(sorted(records[0].json["Link"])).toEqual(["Luke", "Mark"]);
+  });
+
+  test("resolves linked rows when fetching all records", async () => {
+    const adaptor = getAdaptor();
+    const linksByName: Record<string, unknown> = {};
+    for await (const record of adaptor.fetchAll()) {
+      linksByName[String(record.json["Name"])] = sorted(record.json["Link"]);
+    }
+    expect(linksByName["Sleve McDichael"]).toEqual(["Luke", "Mark"]);
+    expect(linksByName["Onson Sweemy"]).toEqual(["John"]);
+  });
+
+  // Select fields must come through as plain strings, as they do in Airtable,
+  // rather than as Baserow's `{ id, value, color }` objects
+  test("unwraps select fields", async () => {
+    const adaptor = getAdaptor();
+    const [record] = await adaptor.fetchByExternalId(["1"]);
+    expect(record.json["Status"]).toBe("Active");
+    expect(sorted(record.json["Tags"])).toEqual(["Blue", "Red"]);
+  });
+
+  test("leaves empty select fields empty", async () => {
+    const adaptor = getAdaptor();
+    const [record] = await adaptor.fetchByExternalId(["2"]);
+    expect(record.json["Status"]).toBeNull();
+    expect(record.json["Tags"]).toEqual([]);
+  });
+
+  test("fetchByExternalId skips deleted rows", async () => {
+    const adaptor = getAdaptor();
+    const result = await adaptor.fetchByExternalId(["999999999"]);
+    expect(result).toEqual([]);
+  });
+
+  test("extractExternalRecordIdsFromWebhookBody yields created row IDs", async () => {
+    const adaptor = getAdaptor();
+    const body = {
+      table_id: Number(credentials.baserow.tableId),
+      event_type: "rows.created",
+      items: [{ id: 123 }, { id: 456 }],
+    };
+    const ids = [];
+    for await (const id of adaptor.extractExternalRecordIdsFromWebhookBody(
+      body,
+    )) {
+      ids.push(id);
+    }
+    expect(ids).toEqual(["123", "456"]);
+  });
+
+  test("extractExternalRecordIdsFromWebhookBody yields deleted row IDs", async () => {
+    const adaptor = getAdaptor();
+    const body = {
+      table_id: Number(credentials.baserow.tableId),
+      event_type: "rows.deleted",
+      row_ids: [789],
+    };
+    const ids = [];
+    for await (const id of adaptor.extractExternalRecordIdsFromWebhookBody(
+      body,
+    )) {
+      ids.push(id);
+    }
+    expect(ids).toEqual(["789"]);
+  });
+
+  test("extractExternalRecordIdsFromWebhookBody ignores other tables", async () => {
+    const adaptor = getAdaptor();
+    const body = {
+      table_id: Number(credentials.baserow.tableId) + 1,
+      event_type: "rows.created",
+      items: [{ id: 123 }],
+    };
+    const ids = [];
+    for await (const id of adaptor.extractExternalRecordIdsFromWebhookBody(
+      body,
+    )) {
+      ids.push(id);
+    }
+    expect(ids).toEqual([]);
+  });
+
+  test("createField then deleteColumn round-trips", async () => {
+    const adaptor = getAdaptor();
+    try {
+      await adaptor.createField(ENRICHMENT_COLUMN, ColumnType.Number);
+    } catch (e) {
+      expect(String(e)).toContain("ERROR_FIELD_WITH_SAME_NAME_ALREADY_EXISTS");
+    }
+
+    const fields = await adaptor.getFields();
+    expect(fields.map((field) => field.name)).toContain(ENRICHMENT_COLUMN);
+
+    await adaptor.deleteColumn(ENRICHMENT_COLUMN);
+
+    // Use a fresh adaptor so the field list is not read from the cache
+    const freshFields = await getAdaptor().getFields();
+    expect(freshFields.map((field) => field.name)).not.toContain(
+      ENRICHMENT_COLUMN,
+    );
+  });
+
+  test("deleteColumn refuses non-enrichment columns", async () => {
+    const adaptor = getAdaptor();
+    await expect(adaptor.deleteColumn("Name")).rejects.toThrow(
+      /Refusing to delete column/,
+    );
+  });
+
+  test("tagRecords creates the column and writes the tag", async () => {
+    const adaptor = getAdaptor();
+    const firstRow = await adaptor.fetchFirst();
+    if (!firstRow) throw new Error("No records in table");
+
+    await adaptor.tagRecords([
+      {
+        externalId: firstRow.externalId,
+        json: firstRow.json,
+        tag: { name: TAG_COLUMN, present: true },
+      },
+    ]);
+
+    const [tagged] = await adaptor.fetchByExternalId([firstRow.externalId]);
+    expect(tagged.json[TAG_COLUMN]).toBe(true);
+
+    await adaptor.tagRecords([
+      {
+        externalId: firstRow.externalId,
+        json: firstRow.json,
+        tag: { name: TAG_COLUMN, present: false },
+      },
+    ]);
+
+    const [untagged] = await adaptor.fetchByExternalId([firstRow.externalId]);
+    expect(untagged.json[TAG_COLUMN]).toBe(false);
+  });
+
+  test("webhooks", async () => {
+    const adaptor = getAdaptor();
+
+    // Start from a clean slate so the reported lifecycle is deterministic
+    await adaptor.toggleWebhook(false);
+
+    // Enabling with no existing webhook creates one and reports the new id
+    const created = await adaptor.toggleWebhook(true);
+    expect(created.action).toBe("created");
+    expect(created.oldWebhookIds).toEqual([]);
+    expect(created.newWebhookIds).toHaveLength(1);
+
+    const webhooks = await adaptor.listWebhooks(await getPublicUrl());
+    expect(webhooks).toHaveLength(1);
+    expect(webhooks[0].active).toBe(true);
+
+    // Enabling again keeps the existing, still-active webhook
+    const kept = await adaptor.toggleWebhook(true);
+    expect(kept.action).toBe("kept");
+    expect(kept.newWebhookIds).toEqual(created.newWebhookIds);
+
+    // Disabling removes it and reports what was removed
+    const removed = await adaptor.toggleWebhook(false);
+    expect(removed.action).toBe("removed");
+    expect(removed.oldWebhookIds).toEqual(created.newWebhookIds);
+    expect(removed.newWebhookIds).toEqual([]);
+
+    expect(await adaptor.listWebhooks(await getPublicUrl())).toEqual([]);
+
+    // Disabling when there is nothing to remove is a no-op
+    const noop = await adaptor.toggleWebhook(false);
+    expect(noop.action).toBe("noop");
+  });
+});

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -9,6 +9,12 @@ declare module "vitest" {
         tableId: string;
         apiKey: string;
       };
+      baserow: {
+        apiUrl: string;
+        tableId: string;
+        email: string;
+        password: string;
+      };
       googlesheets: {
         spreadsheetId: string;
         sheetName: string;


### PR DESCRIPTION
Adds Baserow alongside the existing CRM integrations, with import, enrichment write-back, tagging, column deletion and webhook-driven auto-import.

Baserow has no OAuth flow, and its database tokens are rejected by the field and webhook endpoints, so the adaptor signs in with an account email and password to obtain a JWT. Refresh tokens expire after 7 days and are not rotated, so the password has to be stored for background syncs to keep working; the form recommends creating a dedicated bot account to bound the blast radius, and the config panel now masks password values.

The API base URL is configurable to support self-hosted instances.

Link and select field values are unwrapped from Baserow's `{ id, value }` objects to the plain strings and string arrays that Airtable already returns, so they can be filtered and mapped rather than importing as ColumnType.Object.

Tests run against the real Baserow API; the table fixture they expect is documented at the top of the test file.
