### PR TITLE
chore(deps): bump nodemailer from 8 to 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "next-sanity": "^12.0.4",
         "next-themes": "^0.4.6",
         "node-html-parser": "^7.0.1",
-        "nodemailer": "^8.0.4",
+        "nodemailer": "^9.0.3",
         "nprogress": "^0.2.0",
         "pg": "^8.14.0",
         "pg-boss": "^12.14.0",
@@ -27875,9 +27875,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
-      "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "next-sanity": "^12.0.4",
     "next-themes": "^0.4.6",
     "node-html-parser": "^7.0.1",
-    "nodemailer": "^8.0.4",
+    "nodemailer": "^9.0.3",
     "nprogress": "^0.2.0",
     "pg": "^8.14.0",
     "pg-boss": "^12.14.0",


### PR DESCRIPTION
Closes the last high-severity advisory that had no in-range fix. The message-level `raw` option bypasses `disableFileAccess`, and the advisory range is `<=9.0.0`, so 9.0.x is the only way out — `npm audit fix` cannot reach it.

## Why this is low risk

v9 has exactly one breaking change: HTTPS requests made **while fetching remote content** now validate TLS certificates by default. That covers attachment `href`/`path` URLs, OAuth2 token endpoints, and HTTP/HTTPS proxy CONNECT.

None of those apply to `src/server/services/mailer.tsx`, which is the only place nodemailer is used:

- `sendEmail` passes rendered HTML — no attachments, so no remote fetches.
- Production uses plain SMTP auth against `mail.smtp2go.com` — no OAuth2.
- Development uses mailpit on `localhost:1025` with `ignoreTLS: true`.

## Verification

Rather than trusting the changelog, I sent a real email through the app's own `sendEmail` into the local mailpit container and asserted via mailpit's API that it arrived with the right recipient. That test was temporary and is not in this diff — CI has only Postgres and Redis, so a mailpit-dependent test would fail there.

Also: `npm run lint`, `npm run build`.

## Note

Stacked on #455 — the base will retarget to `main` automatically once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
