### PR TITLE
feat: read-only shared map viewer with password gate

### DIFF
--- a/src/app/(private)/map/[id]/atoms/mapStateAtoms.ts
+++ b/src/app/(private)/map/[id]/atoms/mapStateAtoms.ts
@@ -13,6 +13,14 @@ export const mapModeAtom = atom<MapMode>("private");
  */
 export const isPublicMapRouteAtom = atom<boolean>(false);
 
+/**
+ * `true` on the read-only shared map page (`/share/[token]`), `false`
+ * everywhere else. Components use `useMapEditable()` to hide editing
+ * affordances, and `useMapViews` skips server writes so view-config
+ * changes (map style, timeline) stay client-side only.
+ */
+export const isReadOnlyRouteAtom = atom<boolean>(false);
+
 /** Derived: the navbar is visible exactly when we are NOT on the public route. */
 export const showNavbarAtom = atom<boolean>(
   (get) => !get(isPublicMapRouteAtom),

--- a/src/app/(private)/map/[id]/components/InspectorPanel/ConfigurableDataRecordsPanel.tsx
+++ b/src/app/(private)/map/[id]/components/InspectorPanel/ConfigurableDataRecordsPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMapEditable } from "../../hooks/useMapEditable";
 import { useOpenInspectorConfig } from "../../hooks/useOpenInspectorConfig";
 import DataRecordsPanel from "./DataRecordsPanel";
 import { InspectorConfigModal } from "./InspectorConfigModal";
@@ -20,6 +21,7 @@ export default function ConfigurableDataRecordsPanel({
 }) {
   const { config, isModalOpen, setIsModalOpen, openConfig, onUpdateConfig } =
     useOpenInspectorConfig(dataSourceId);
+  const editable = useMapEditable();
 
   return (
     <>
@@ -29,7 +31,7 @@ export default function ConfigurableDataRecordsPanel({
         isLoading={isLoading}
         defaultExpanded={defaultExpanded}
         hint={hint}
-        onClickConfigure={openConfig}
+        onClickConfigure={editable ? openConfig : undefined}
       />
       {config && (
         <InspectorConfigModal

--- a/src/app/(private)/map/[id]/components/InspectorPanel/InspectorDataTab.tsx
+++ b/src/app/(private)/map/[id]/components/InspectorPanel/InspectorDataTab.tsx
@@ -3,6 +3,7 @@ import { LayersIcon, Settings2Icon } from "lucide-react";
 import { useState } from "react";
 import { useInspectorContent } from "@/app/(private)/map/[id]/hooks/useInspector";
 import { useInspectorState } from "@/app/(private)/map/[id]/hooks/useInspectorState";
+import { useMapEditable } from "@/app/(private)/map/[id]/hooks/useMapEditable";
 import { useOpenInspectorConfig } from "@/app/(private)/map/[id]/hooks/useOpenInspectorConfig";
 import { useViewInspectorConfig } from "@/app/(private)/map/[id]/hooks/useViewInspectorConfig";
 import DataSourceIcon from "@/components/DataSourceIcon";
@@ -88,6 +89,7 @@ export default function InspectorDataTab() {
   const [configDialogOpen, setConfigDialogOpen] = useState(false);
   const { config, isModalOpen, setIsModalOpen, openConfig, onUpdateConfig } =
     useOpenInspectorConfig(dataSource?.id);
+  const editable = useMapEditable();
 
   const { data: recordData, isFetching: recordLoading } = useQuery(
     trpc.dataRecord.byId.queryOptions(
@@ -238,15 +240,17 @@ export default function InspectorDataTab() {
                   <p className="truncate">{dataSource.name}</p>
                 </div>
               </div>
-              <button
-                type="button"
-                className="cursor-pointer shrink-0 text-muted-foreground hover:text-foreground"
-                aria-label="Configure inspector"
-                title="Configure inspector"
-                onClick={openConfig}
-              >
-                <Settings2Icon className="h-4 w-4" />
-              </button>
+              {editable && (
+                <button
+                  type="button"
+                  className="cursor-pointer shrink-0 text-muted-foreground hover:text-foreground"
+                  aria-label="Configure inspector"
+                  title="Configure inspector"
+                  onClick={openConfig}
+                >
+                  <Settings2Icon className="h-4 w-4" />
+                </button>
+              )}
             </div>
           )}
 
@@ -311,15 +315,17 @@ export default function InspectorDataTab() {
             defaultExpanded={index === 0}
           />
         ))}
-      <Button
-        variant="outline"
-        className="w-full"
-        size="sm"
-        onClick={() => setConfigDialogOpen(true)}
-      >
-        <Settings2Icon />
-        Manage inspector data
-      </Button>
+      {editable && (
+        <Button
+          variant="outline"
+          className="w-full"
+          size="sm"
+          onClick={() => setConfigDialogOpen(true)}
+        >
+          <Settings2Icon />
+          Manage inspector data
+        </Button>
+      )}
       <Dialog open={configDialogOpen} onOpenChange={setConfigDialogOpen}>
         <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto">
           <DialogHeader>

--- a/src/app/(private)/map/[id]/components/InspectorPanel/InspectorPanel.tsx
+++ b/src/app/(private)/map/[id]/components/InspectorPanel/InspectorPanel.tsx
@@ -17,6 +17,7 @@ import { useDisplayAreaStat } from "@/app/(private)/map/[id]/hooks/useDisplayAre
 import { useInspectorContent } from "@/app/(private)/map/[id]/hooks/useInspector";
 import { useInspectorState } from "@/app/(private)/map/[id]/hooks/useInspectorState";
 import { useMapRef } from "@/app/(private)/map/[id]/hooks/useMapCore";
+import { useMapEditable } from "@/app/(private)/map/[id]/hooks/useMapEditable";
 import { useSelectedAreas } from "@/app/(private)/map/[id]/hooks/useSelectedAreas";
 import { useSelectedSecondaryArea } from "@/app/(private)/map/[id]/hooks/useSelectedSecondaryArea";
 import { useTable } from "@/app/(private)/map/[id]/hooks/useTable";
@@ -55,6 +56,7 @@ export default function InspectorPanel() {
   const [selectedSecondaryArea] = useSelectedSecondaryArea();
   const [selectedAreas, setSelectedAreas] = useSelectedAreas();
   const organisationId = useOrganisationId();
+  const editable = useMapEditable();
 
   // Selecting something new re-opens a minimised inspector
   const contentKey = `${type ?? ""}:${String(inspectorContent?.name ?? "")}`;
@@ -365,14 +367,16 @@ export default function InspectorPanel() {
       </UnderlineTabs>
       {type === LayerType.Boundary && (
         <div className="border-t p-3 flex flex-col gap-2">
-          <Button
-            className="w-full"
-            onClick={handleAddToMyAreas}
-            disabled={savingTurf || !areaGeoJson}
-          >
-            <PlusIcon />
-            Add to areas
-          </Button>
+          {editable && (
+            <Button
+              className="w-full"
+              onClick={handleAddToMyAreas}
+              disabled={savingTurf || !areaGeoJson}
+            >
+              <PlusIcon />
+              Add to areas
+            </Button>
+          )}
           <Button
             variant="secondary"
             className="w-full"
@@ -386,7 +390,8 @@ export default function InspectorPanel() {
       )}
       {hasData &&
         type !== LayerType.Boundary &&
-        ((isDetailsView && focusedRecord?.geocodePoint) || dataSource) && (
+        ((isDetailsView && focusedRecord?.geocodePoint) ||
+          (dataSource && editable)) && (
           <div className="border-t p-3 flex flex-col gap-2">
             {isDetailsView && focusedRecord?.geocodePoint && (
               <Button onClick={handleFlyToMarker}>
@@ -394,7 +399,7 @@ export default function InspectorPanel() {
                 View on map
               </Button>
             )}
-            {dataSource && (
+            {dataSource && editable && (
               <Button
                 variant="secondary"
                 onClick={() => setSelectedDataSourceId(dataSource.id)}

--- a/src/app/(private)/map/[id]/components/Legend/LegendDisplay.tsx
+++ b/src/app/(private)/map/[id]/components/Legend/LegendDisplay.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { LoaderPinwheel } from "lucide-react";
+import { useMapViews } from "@/app/(private)/map/[id]/hooks/useMapViews";
+import { DUMMY_COUNT_COLUMN } from "@/constants";
+import { useChoroplethDataSource } from "@/hooks/useDataSources";
+import { AreaSetGroupCodeLabels } from "@/labels";
+import { useColorScheme } from "../../colors";
+import { useAreaStats } from "../../data";
+import BivariateLegend from "../BivariateLagend";
+import { LegendBars } from "./LegendBars";
+
+/**
+ * Display-only legend for the read-only shared map page: the choropleth
+ * colour bars and their labels, with none of the editor `Legend`'s data
+ * source / column / boundary configuration controls.
+ */
+export default function LegendDisplay() {
+  const { viewConfig } = useMapViews();
+  const dataSource = useChoroplethDataSource();
+
+  const areaStatsQuery = useAreaStats();
+  const areaStats = areaStatsQuery?.data;
+  const isLoading = areaStatsQuery?.isFetching;
+
+  const colorScheme = useColorScheme({
+    areaStats,
+    viewConfig,
+  });
+
+  const hasColumn = Boolean(viewConfig.areaDataColumn);
+  if (!viewConfig.areaDataSourceId || !hasColumn) {
+    return null;
+  }
+
+  const isCount = viewConfig.areaDataColumn === DUMMY_COUNT_COLUMN;
+  const isBivariate = Boolean(
+    !isCount && viewConfig.areaDataColumn && viewConfig.areaDataSecondaryColumn,
+  );
+
+  const columnLabel = isCount
+    ? "Count of records"
+    : viewConfig.areaDataColumn || "";
+  const boundaryLabel = viewConfig.areaSetGroupCode
+    ? AreaSetGroupCodeLabels[viewConfig.areaSetGroupCode]
+    : null;
+
+  return (
+    <div className="flex flex-col rounded-sm bg-white border border-neutral-200 w-full shadow-sm">
+      <div className="flex flex-col gap-0.5 p-2 pb-1">
+        <p className="text-xs font-semibold truncate">{columnLabel}</p>
+        <p className="text-[11px] text-muted-foreground truncate">
+          {dataSource?.name}
+          {boundaryLabel ? ` · ${boundaryLabel}` : ""}
+        </p>
+      </div>
+      {isLoading ? (
+        <div className="flex items-center justify-center px-3 py-4">
+          <LoaderPinwheel className="w-5 h-5 animate-spin text-neutral-400" />
+        </div>
+      ) : isBivariate ? (
+        <div className="px-2 pb-2">
+          <BivariateLegend />
+        </div>
+      ) : colorScheme ? (
+        <div className="flex px-2 pb-2">
+          <LegendBars
+            colorScheme={colorScheme}
+            viewConfig={viewConfig}
+            areaStats={areaStats}
+            dataSource={dataSource}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(private)/map/[id]/components/readonly/ReadOnlyMapControls.tsx
+++ b/src/app/(private)/map/[id]/components/readonly/ReadOnlyMapControls.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import { MapType } from "@/models/MapView";
+import { useMapViews } from "../../hooks/useMapViews";
+import BoundaryHoverInfo from "../BoundaryHoverInfo/BoundaryHoverInfo";
+import InspectorPanel from "../InspectorPanel/InspectorPanel";
+import LegendDisplay from "../Legend/LegendDisplay";
+import MarkerLegend from "../Legend/MarkerLegend";
+import MapStyleSelector from "../MapStyleSelector";
+import TimelineControl from "../TimelineControl";
+import ZoomControl from "../ZoomControl";
+
+/**
+ * Map furniture for the read-only shared map page: the boundary hover
+ * info, the inspector, display-only legends, and the map style / zoom /
+ * timeline controls. No control panels, no draw or pin-drop modes.
+ */
+export default function ReadOnlyMapControls() {
+  const { viewConfig } = useMapViews();
+
+  // Lets global.css place the report-a-bug trigger in a row with the map's
+  // zoom controls (it defaults to the corner the zoom controls occupy)
+  useEffect(() => {
+    document.body.classList.add("map-page");
+    return () => document.body.classList.remove("map-page");
+  }, []);
+
+  return (
+    <>
+      <div className="absolute top-5 left-4 right-4 bottom-[100px] z-10 pointer-events-none flex justify-between items-start gap-4">
+        <BoundaryHoverInfo />
+        <InspectorPanel />
+      </div>
+
+      <div className="absolute bottom-8 left-8 z-10 hidden md:flex flex-col gap-2 w-64 pointer-events-auto">
+        <MarkerLegend />
+        <LegendDisplay />
+        <MapStyleSelector />
+      </div>
+
+      <div className="map-zoom-controls / absolute bottom-8 right-8 z-10 hidden md:block">
+        <ZoomControl />
+      </div>
+
+      {viewConfig.mapType !== MapType.Hex && (
+        <div
+          className="absolute left-1/2 z-10"
+          style={{ transform: "translate(-50%)", bottom: "32px" }}
+        >
+          <TimelineControl />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/(private)/map/[id]/components/readonly/ReadOnlyMapViews.tsx
+++ b/src/app/(private)/map/[id]/components/readonly/ReadOnlyMapViews.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { cn } from "@/shadcn/utils";
+import { useMapViews, useViewIdAtom } from "../../hooks/useMapViews";
+
+/**
+ * View switcher for the read-only shared map page: lists the map's views
+ * and switches between them. No create / rename / reorder / delete.
+ */
+export default function ReadOnlyMapViews() {
+  const { views } = useMapViews();
+  const [viewId, setViewId] = useViewIdAtom();
+
+  if (views.length < 2) {
+    return null;
+  }
+
+  const sortedViews = [...views].sort((a, b) => a.position - b.position);
+
+  const onSelectView = (id: string) => {
+    setViewId(id);
+    // Keep the URL shareable without a navigation
+    const url = new URL(window.location.href);
+    url.searchParams.set("viewId", id);
+    window.history.replaceState(null, "", url.toString());
+  };
+
+  return (
+    <div className="flex items-center gap-1 overflow-x-auto">
+      {sortedViews.map((view) => (
+        <button
+          key={view.id}
+          type="button"
+          className={cn(
+            "px-3 py-1 rounded text-sm whitespace-nowrap cursor-pointer transition-colors",
+            view.id === viewId
+              ? "bg-neutral-100 font-medium"
+              : "text-neutral-500 hover:text-neutral-800 hover:bg-neutral-50",
+          )}
+          onClick={() => onSelectView(view.id)}
+        >
+          {view.name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(private)/map/[id]/components/readonly/ReadOnlyNavbar.tsx
+++ b/src/app/(private)/map/[id]/components/readonly/ReadOnlyNavbar.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Navbar from "@/components/layout/Navbar";
+import { useMapId } from "../../hooks/useMapCore";
+import { useMapQuery } from "../../hooks/useMapQuery";
+import ReadOnlyMapViews from "./ReadOnlyMapViews";
+
+/**
+ * Navbar for the read-only shared map page: map name, view switcher and
+ * area search. None of the private navbar's editing affordances — and
+ * crucially none of its side effects (initial-view creation, thumbnail
+ * upload), which write to the map.
+ */
+export default function ReadOnlyNavbar() {
+  const mapId = useMapId();
+  const { data: map } = useMapQuery(mapId);
+
+  return (
+    <Navbar>
+      <div className="flex justify-between items-center gap-4 w-full">
+        <div className="flex items-center gap-4 min-w-0">
+          <p className="truncate max-w-[300px] text-sm text-neutral-600">
+            {map ? map.name : "Loading..."}
+          </p>
+          <ReadOnlyMapViews />
+        </div>
+        <SearchBox />
+      </div>
+    </Navbar>
+  );
+}
+
+const SearchBox = dynamic(
+  () => import("../SearchBox").then((mod) => ({ default: mod.SearchBox })),
+  {
+    ssr: false,
+    loading: () => null,
+  },
+);

--- a/src/app/(private)/map/[id]/components/readonly/ReadOnlyNavbar.tsx
+++ b/src/app/(private)/map/[id]/components/readonly/ReadOnlyNavbar.tsx
@@ -17,17 +17,19 @@ export default function ReadOnlyNavbar() {
   const { data: map } = useMapQuery(mapId);
 
   return (
-    <Navbar>
-      <div className="flex justify-between items-center gap-4 w-full">
-        <div className="flex items-center gap-4 min-w-0">
-          <p className="truncate max-w-[300px] text-sm text-neutral-600">
-            {map ? map.name : "Loading..."}
-          </p>
-          <ReadOnlyMapViews />
+    <div className="pointer-events-auto">
+      <Navbar>
+        <div className="flex justify-between items-center gap-4 w-full">
+          <div className="flex items-center gap-4 min-w-0">
+            <p className="truncate max-w-[300px] text-sm text-neutral-600">
+              {map ? map.name : "Loading..."}
+            </p>
+            <ReadOnlyMapViews />
+          </div>
+          <SearchBox />
         </div>
-        <SearchBox />
-      </div>
-    </Navbar>
+      </Navbar>
+    </div>
   );
 }
 

--- a/src/app/(private)/map/[id]/hooks/useMapEditable.ts
+++ b/src/app/(private)/map/[id]/hooks/useMapEditable.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useAtomValue } from "jotai";
+import { isReadOnlyRouteAtom } from "../atoms/mapStateAtoms";
+
+/** `true` on the read-only shared map page (`/share/[token]`). */
+export function useIsReadOnlyRoute() {
+  return useAtomValue(isReadOnlyRouteAtom);
+}
+
+/**
+ * Whether the current viewer may edit the map. `false` only on the
+ * read-only shared map page — components use this to hide editing
+ * affordances (inspector config, add-to-areas, view-in-table, etc.).
+ */
+export function useMapEditable() {
+  return !useAtomValue(isReadOnlyRouteAtom);
+}

--- a/src/app/(private)/map/[id]/hooks/useMapViews.ts
+++ b/src/app/(private)/map/[id]/hooks/useMapViews.ts
@@ -12,6 +12,7 @@ import { createNewViewConfig } from "../utils/mapView";
 import { getNewLastPosition } from "../utils/position";
 import { useDebouncedCallback } from "./useDebouncedCallback";
 import { useMapId } from "./useMapCore";
+import { useIsReadOnlyRoute } from "./useMapEditable";
 import { useMapQuery } from "./useMapQuery";
 import type { View } from "../types";
 
@@ -23,6 +24,11 @@ export function useMapViews() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const { data: mapData } = useMapQuery(mapId);
+  // On the read-only shared map page, view-config changes (map style,
+  // timeline range) update the query cache for instant feedback but are
+  // never persisted — anonymous viewers cannot write, and their tweaks
+  // should reset on reload.
+  const isReadOnlyRoute = useIsReadOnlyRoute();
 
   // Get views directly from cache
   const views = mapData?.views;
@@ -73,7 +79,7 @@ export function useMapViews() {
 
   const insertView = useCallback(
     (view: Omit<View, "position">) => {
-      if (!mapId) return;
+      if (!mapId || isReadOnlyRoute) return;
 
       const newView = {
         ...view,
@@ -102,6 +108,7 @@ export function useMapViews() {
     },
     [
       mapId,
+      isReadOnlyRoute,
       views,
       setViewId,
       setDirtyViewIds,
@@ -155,7 +162,9 @@ export function useMapViews() {
       const updatedViews =
         views?.map((v) => (v.id === view.id ? view : v)) || [];
 
-      setDirtyViewIds((ids) => ids.concat([view.id]));
+      if (!isReadOnlyRoute) {
+        setDirtyViewIds((ids) => ids.concat([view.id]));
+      }
 
       // Synchronously update cache BEFORE calling mutation for instant UI feedback
       queryClient.setQueryData(trpc.map.byId.queryKey({ mapId }), (old) => {
@@ -171,10 +180,13 @@ export function useMapViews() {
         };
       });
 
-      updateViewMutate({ mapId, views: updatedViews });
+      if (!isReadOnlyRoute) {
+        updateViewMutate({ mapId, views: updatedViews });
+      }
     },
     [
       mapId,
+      isReadOnlyRoute,
       setDirtyViewIds,
       queryClient,
       trpc.map.byId,
@@ -247,7 +259,7 @@ export function useMapViews() {
 
   const deleteView = useCallback(
     (viewId: string) => {
-      if (!mapId) return;
+      if (!mapId || isReadOnlyRoute) return;
 
       // Synchronously update cache BEFORE calling mutation for instant UI feedback
       queryClient.setQueryData(trpc.map.byId.queryKey({ mapId }), (old) => {
@@ -260,7 +272,7 @@ export function useMapViews() {
 
       deleteViewMutate({ mapId, viewId });
     },
-    [mapId, queryClient, trpc.map.byId, deleteViewMutate],
+    [mapId, isReadOnlyRoute, queryClient, trpc.map.byId, deleteViewMutate],
   );
 
   return {

--- a/src/app/(private)/map/[id]/hooks/useMarkerQueries.ts
+++ b/src/app/(private)/map/[id]/hooks/useMarkerQueries.ts
@@ -41,8 +41,9 @@ export function useMarkerQueries() {
 
       // Columns used by this view's marker styling must be present on the
       // marker features for Mapbox match expressions to read them. Only
-      // honoured by the server for authenticated readers. Sorted so the
-      // query key is stable regardless of config field order.
+      // honoured by the server for authenticated readers and shared-map
+      // viewers whose grant covers the data source. Sorted so the query
+      // key is stable regardless of config field order.
       const visualisation = view?.config.markerVisualisations?.[dataSourceId];
       const propertyColumns = [
         ...new Set(

--- a/src/app/(private)/map/[id]/providers/MapJotaiProvider.tsx
+++ b/src/app/(private)/map/[id]/providers/MapJotaiProvider.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import {
   type MapMode,
   isPublicMapRouteAtom,
+  isReadOnlyRouteAtom,
   mapIdAtom,
   mapModeAtom,
   viewIdAtom,
@@ -18,16 +19,21 @@ import type { ReactNode } from "react";
  * `isPublicMapRoute` is `true` only on the standalone public page (`/public/[host]`).
  * The navbar visibility and editor-mode flag are derived from this single boolean,
  * and `mapMode` is derived from the URL.
+ *
+ * `isReadOnlyRoute` is `true` only on the shared map page (`/share/[token]`),
+ * where anonymous viewers see the private map without editing affordances.
  */
 export default function MapJotaiProvider({
   mapId,
   viewId,
   isPublicMapRoute = false,
+  isReadOnlyRoute = false,
   children,
 }: {
   mapId: string;
   viewId?: string;
   isPublicMapRoute?: boolean;
+  isReadOnlyRoute?: boolean;
   children: ReactNode;
 }) {
   return (
@@ -36,6 +42,7 @@ export default function MapJotaiProvider({
         mapId={mapId}
         viewId={viewId}
         isPublicMapRoute={isPublicMapRoute}
+        isReadOnlyRoute={isReadOnlyRoute}
       >
         {children}
       </HydrateAtoms>
@@ -47,11 +54,13 @@ function HydrateAtoms({
   mapId,
   viewId,
   isPublicMapRoute,
+  isReadOnlyRoute,
   children,
 }: {
   mapId: string;
   viewId?: string;
   isPublicMapRoute: boolean;
+  isReadOnlyRoute: boolean;
   children: ReactNode;
 }) {
   // On the private route, derive mapMode + viewId from the URL so the very
@@ -71,6 +80,7 @@ function HydrateAtoms({
     [viewIdAtom, resolvedViewId || null],
     [mapModeAtom, resolvedMapMode],
     [isPublicMapRouteAtom, isPublicMapRoute],
+    [isReadOnlyRouteAtom, isReadOnlyRoute],
   ]);
 
   return children;

--- a/src/app/api/data-sources/[id]/markers/route.ts
+++ b/src/app/api/data-sources/[id]/markers/route.ts
@@ -4,9 +4,13 @@ import { getShareGrants } from "@/auth/shareGrants";
 import { MARKER_MATCHED_COLUMN } from "@/constants";
 import { streamDataRecordsByDataSource } from "@/server/repositories/DataRecord";
 import { findDataSourceById } from "@/server/repositories/DataSource";
+import { findMapShareVisualisingDataSource } from "@/server/repositories/MapShare";
 import { findOrganisationForUser } from "@/server/repositories/Organisation";
 import { findPublicMapByViewId } from "@/server/repositories/PublicMap";
-import { canReadDataSource } from "@/server/utils/auth";
+import {
+  canReadDataSource,
+  getValidShareGrantMapIds,
+} from "@/server/utils/auth";
 import { closeRecordStream } from "@/server/utils/stream";
 import {
   buildName,
@@ -72,15 +76,28 @@ export async function GET(
 
   // Marker styling (icon/size/colour by column) needs the raw column values on
   // the features. The column list is client-supplied but only honoured for
-  // authenticated users: `canReadDataSource` passes anonymous requests for
-  // public data sources and published public maps, and those must stay on
-  // minimal properties. Authenticated readers can already fetch full record
-  // JSON via tRPC, so this grants them nothing new.
-  const includeProperties = currentUser?.id
-    ? parseIncludeProperties(
-        request?.nextUrl?.searchParams.get("properties") || null,
-      )
-    : [];
+  // authenticated users and shared-map viewers whose grant covers this data
+  // source: `canReadDataSource` also passes anonymous requests for public
+  // data sources and published public maps, and those must stay on minimal
+  // properties. Grant holders and authenticated readers can already fetch
+  // full record JSON via tRPC, so this grants them nothing new.
+  const sharedMapIds = currentUser?.id
+    ? []
+    : await getValidShareGrantMapIds(shareGrants);
+  const grantCoversDataSource =
+    sharedMapIds.length > 0 &&
+    Boolean(
+      await findMapShareVisualisingDataSource({
+        dataSourceId: dataSource.id,
+        mapIds: sharedMapIds,
+      }),
+    );
+  const includeProperties =
+    currentUser?.id || grantCoversDataSource
+      ? parseIncludeProperties(
+          request?.nextUrl?.searchParams.get("properties") || null,
+        )
+      : [];
 
   // Timeline filtering: when the data source declares a date column, expose
   // the record's month key, derived from the date parsed at import time

--- a/src/app/api/share/[token]/claim/route.ts
+++ b/src/app/api/share/[token]/claim/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { addShareGrant } from "@/auth/shareGrants";
+import { findMapShareByToken } from "@/server/repositories/MapShare";
+import type { NextRequest } from "next/server";
+
+/**
+ * Mints the grant cookie for a passwordless share and bounces back to the
+ * share page. Exists because Next.js forbids setting cookies during page
+ * render. Password-protected shares are never minted here — the page shows
+ * the password form, and the verify endpoint mints instead.
+ */
+export async function GET(
+  request: NextRequest,
+  args: { params: Promise<{ token: string }> },
+): Promise<NextResponse> {
+  const { token } = await args.params;
+  const share = await findMapShareByToken(token);
+
+  const shareUrl = new URL(`/share/${token}`, request.nextUrl.origin);
+  const viewId = request.nextUrl.searchParams.get("viewId");
+  if (viewId) {
+    shareUrl.searchParams.set("viewId", viewId);
+  }
+
+  if (share && share.enabled && !share.passwordHash) {
+    await addShareGrant({ shareId: share.id, mapId: share.mapId });
+    // Marks the claim as attempted so the page can detect blocked cookies
+    // instead of redirecting here again
+    shareUrl.searchParams.set("c", "1");
+  }
+
+  return NextResponse.redirect(shareUrl);
+}

--- a/src/app/api/share/[token]/claim/route.ts
+++ b/src/app/api/share/[token]/claim/route.ts
@@ -4,30 +4,25 @@ import { findMapShareByToken } from "@/server/repositories/MapShare";
 import type { NextRequest } from "next/server";
 
 /**
- * Mints the grant cookie for a passwordless share and bounces back to the
- * share page. Exists because Next.js forbids setting cookies during page
- * render. Password-protected shares are never minted here — the page shows
- * the password form, and the verify endpoint mints instead.
+ * Mints the grant cookie for a passwordless share. Called by the share
+ * page's `ShareClaim` component (Next.js forbids setting cookies during
+ * page render); the client then refreshes so the server component sees
+ * the grant. Password-protected shares are never minted here — the page
+ * shows the password form, and the verify endpoint mints instead.
  */
-export async function GET(
-  request: NextRequest,
+export async function POST(
+  _request: NextRequest,
   args: { params: Promise<{ token: string }> },
 ): Promise<NextResponse> {
   const { token } = await args.params;
   const share = await findMapShareByToken(token);
-
-  const shareUrl = new URL(`/share/${token}`, request.nextUrl.origin);
-  const viewId = request.nextUrl.searchParams.get("viewId");
-  if (viewId) {
-    shareUrl.searchParams.set("viewId", viewId);
+  if (!share || !share.enabled) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+  if (share.passwordHash) {
+    return new NextResponse("Password required", { status: 401 });
   }
 
-  if (share && share.enabled && !share.passwordHash) {
-    await addShareGrant({ shareId: share.id, mapId: share.mapId });
-    // Marks the claim as attempted so the page can detect blocked cookies
-    // instead of redirecting here again
-    shareUrl.searchParams.set("c", "1");
-  }
-
-  return NextResponse.redirect(shareUrl);
+  await addShareGrant({ shareId: share.id, mapId: share.mapId });
+  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/share/[token]/verify/route.ts
+++ b/src/app/api/share/[token]/verify/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { addShareGrant } from "@/auth/shareGrants";
+import { findMapShareByToken } from "@/server/repositories/MapShare";
+import {
+  checkSharePasswordAttempt,
+  getClientIp,
+} from "@/server/services/ratelimit";
+import { verifyPassword } from "@/server/utils/auth";
+import type { NextRequest } from "next/server";
+
+/**
+ * Verifies a shared map's password and mints the grant cookie on success.
+ * Rate-limited per IP + token to resist password guessing.
+ */
+export async function POST(
+  request: NextRequest,
+  args: { params: Promise<{ token: string }> },
+): Promise<NextResponse> {
+  const { token } = await args.params;
+  const share = await findMapShareByToken(token);
+  if (!share || !share.enabled) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  // If the password was removed while the form was open, the claim is free
+  if (!share.passwordHash) {
+    await addShareGrant({ shareId: share.id, mapId: share.mapId });
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const ip = getClientIp(request);
+  const allowed = await checkSharePasswordAttempt(ip, token);
+  if (!allowed) {
+    return new NextResponse("Too many attempts", { status: 429 });
+  }
+
+  let password = "";
+  try {
+    const body: unknown = await request.json();
+    if (
+      body !== null &&
+      typeof body === "object" &&
+      "password" in body &&
+      typeof body.password === "string"
+    ) {
+      password = body.password;
+    }
+  } catch {
+    // Malformed body: treated as an empty password below
+  }
+
+  const valid = password
+    ? await verifyPassword(password, share.passwordHash)
+    : false;
+  if (!valid) {
+    return new NextResponse("Incorrect password", { status: 401 });
+  }
+
+  await addShareGrant({ shareId: share.id, mapId: share.mapId });
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/share/[token]/components/ShareClaim.tsx
+++ b/src/app/share/[token]/components/ShareClaim.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { LoaderPinwheel } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState, useTransition } from "react";
+
+// A claim attempted this recently that still yielded no grant means the
+// browser is not storing our cookies
+const RECENT_CLAIM_WINDOW_MS = 5000;
+
+const CLAIM_ATTEMPT_KEY = "shareClaimAttemptedAt";
+
+/**
+ * The invisible claim step for a passwordless share: on mount, asks the
+ * claim endpoint to mint the grant cookie, then refreshes so the server
+ * component re-renders with the grant — the same mechanism as
+ * `SharePasswordForm`, minus the form. If the refreshed page still has no
+ * grant, the browser is blocking cookies: show a message instead of
+ * claiming again.
+ */
+export default function ShareClaim({ token }: { token: string }) {
+  const router = useRouter();
+  const didRun = useRef(false);
+  const [isRefreshing, startTransition] = useTransition();
+  const [status, setStatus] = useState<"claiming" | "claimed" | "blocked">(
+    "claiming",
+  );
+
+  useEffect(() => {
+    if (didRun.current) {
+      return;
+    }
+    didRun.current = true;
+
+    try {
+      const lastAttempt = Number(sessionStorage.getItem(CLAIM_ATTEMPT_KEY));
+      if (Date.now() - lastAttempt < RECENT_CLAIM_WINDOW_MS) {
+        setStatus("blocked");
+        return;
+      }
+      sessionStorage.setItem(CLAIM_ATTEMPT_KEY, String(Date.now()));
+    } catch {
+      // Storage being unavailable means cookies are blocked too
+      setStatus("blocked");
+      return;
+    }
+
+    const claim = async () => {
+      try {
+        await fetch(`/api/share/${token}/claim`, { method: "POST" });
+      } catch {
+        // Let the refreshed page decide what went wrong (404, password
+        // form, or the blocked-cookies message below)
+      }
+      startTransition(() => router.refresh());
+      setStatus("claimed");
+    };
+    void claim();
+  }, [token, router]);
+
+  // A finished refresh that still renders this component means the server
+  // saw no grant: the cookie did not stick
+  const blocked =
+    status === "blocked" || (status === "claimed" && !isRefreshing);
+
+  if (blocked) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center p-8 text-center">
+        <p className="max-w-[40ch] text-base">
+          This shared map needs cookies to work. Please enable cookies for this
+          site and reload the page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <LoaderPinwheel className="w-6 h-6 animate-spin text-neutral-400" />
+    </div>
+  );
+}

--- a/src/app/share/[token]/components/ShareClaim.tsx
+++ b/src/app/share/[token]/components/ShareClaim.tsx
@@ -8,7 +8,9 @@ import { useEffect, useRef, useState, useTransition } from "react";
 // browser is not storing our cookies
 const RECENT_CLAIM_WINDOW_MS = 5000;
 
-const CLAIM_ATTEMPT_KEY = "shareClaimAttemptedAt";
+// Scoped per token: a successful claim on one share must not mark a
+// different share's link, opened moments later in the same tab, as blocked
+const claimAttemptKey = (token: string) => `shareClaimAttemptedAt:${token}`;
 
 /**
  * The invisible claim step for a passwordless share: on mount, asks the
@@ -33,12 +35,14 @@ export default function ShareClaim({ token }: { token: string }) {
     didRun.current = true;
 
     try {
-      const lastAttempt = Number(sessionStorage.getItem(CLAIM_ATTEMPT_KEY));
+      const lastAttempt = Number(
+        sessionStorage.getItem(claimAttemptKey(token)),
+      );
       if (Date.now() - lastAttempt < RECENT_CLAIM_WINDOW_MS) {
         setStatus("blocked");
         return;
       }
-      sessionStorage.setItem(CLAIM_ATTEMPT_KEY, String(Date.now()));
+      sessionStorage.setItem(claimAttemptKey(token), String(Date.now()));
     } catch {
       // Storage being unavailable means cookies are blocked too
       setStatus("blocked");
@@ -58,8 +62,14 @@ export default function ShareClaim({ token }: { token: string }) {
     void claim();
   }, [token, router]);
 
-  // A finished refresh that still renders this component means the server
-  // saw no grant: the cookie did not stick
+  // Cookie-stick detection, shared with `SharePasswordForm`: the grant
+  // cookie is httpOnly and `router.refresh()` reports nothing back, so the
+  // only way to learn whether the cookie stuck is to see what the server
+  // renders. `isRefreshing` spans the full refresh round-trip, and a
+  // refresh preserves client component state — so once the claim's refresh
+  // has finished, either the server saw the grant and swapped in the map
+  // (unmounting us), or this same instance is still mounted, meaning the
+  // cookie did not stick.
   const blocked =
     status === "blocked" || (status === "claimed" && !isRefreshing);
 

--- a/src/app/share/[token]/components/SharePasswordForm.tsx
+++ b/src/app/share/[token]/components/SharePasswordForm.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { LockIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/shadcn/ui/button";
+import { Input } from "@/shadcn/ui/input";
+
+/**
+ * The password gate for a protected shared map. Submitting posts to the
+ * verify endpoint, which sets the grant cookie; the refresh then re-runs
+ * the server component, which sees the grant and renders the map.
+ */
+export default function SharePasswordForm({
+  token,
+  mapName,
+}: {
+  token: string;
+  mapName: string;
+}) {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!password || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/share/${token}/verify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      if (response.ok) {
+        router.refresh();
+        return;
+      }
+      if (response.status === 429) {
+        setError("Too many attempts. Please try again in a few minutes.");
+      } else {
+        setError("Incorrect password. Please try again.");
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex h-screen w-full items-center justify-center bg-neutral-50 p-4">
+      <form
+        onSubmit={onSubmit}
+        className="flex w-full max-w-sm flex-col gap-4 rounded-lg border border-neutral-200 bg-white p-6 shadow-sm"
+      >
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <LockIcon size={16} className="text-muted-foreground shrink-0" />
+            <h1 className="text-base font-semibold truncate">{mapName}</h1>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            This map is password protected. Enter the password to view it.
+          </p>
+        </div>
+        <Input
+          type="password"
+          value={password}
+          autoFocus
+          placeholder="Password"
+          aria-label="Password"
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <Button type="submit" disabled={!password || submitting}>
+          {submitting ? "Checking..." : "View map"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/share/[token]/components/SharePasswordForm.tsx
+++ b/src/app/share/[token]/components/SharePasswordForm.tsx
@@ -2,7 +2,7 @@
 
 import { LockIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { Button } from "@/shadcn/ui/button";
 import { Input } from "@/shadcn/ui/input";
 
@@ -22,10 +22,12 @@ export default function SharePasswordForm({
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [verified, setVerified] = useState(false);
+  const [isRefreshing, startTransition] = useTransition();
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!password || submitting) {
+    if (!password || submitting || verified) {
       return;
     }
     setSubmitting(true);
@@ -37,7 +39,15 @@ export default function SharePasswordForm({
         body: JSON.stringify({ password }),
       });
       if (response.ok) {
-        router.refresh();
+        setVerified(true);
+        startTransition(() => router.refresh());
+        return;
+      }
+      if (response.status === 404) {
+        // The share was disabled or its token rotated while the form was
+        // open: refresh so the server renders the real outcome (the 404
+        // page) rather than reporting an incorrect password
+        startTransition(() => router.refresh());
         return;
       }
       if (response.status === 429) {
@@ -51,6 +61,26 @@ export default function SharePasswordForm({
       setSubmitting(false);
     }
   };
+
+  // Cookie-stick detection, shared with `ShareClaim`: the grant cookie is
+  // httpOnly and `router.refresh()` reports nothing back, so the only way
+  // to learn whether the cookie stuck is to see what the server renders.
+  // `isRefreshing` spans the full refresh round-trip, and a refresh
+  // preserves client component state — so once a correct password's
+  // refresh has finished, either the server saw the grant and swapped in
+  // the map (unmounting us), or this same instance is still mounted,
+  // meaning the browser is blocking cookies. Without this the form would
+  // silently re-appear and the viewer would resubmit forever.
+  if (verified && !isRefreshing) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center p-8 text-center">
+        <p className="max-w-[40ch] text-base">
+          This shared map needs cookies to work. Please enable cookies for this
+          site and reload the page.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-screen w-full items-center justify-center bg-neutral-50 p-4">
@@ -76,8 +106,11 @@ export default function SharePasswordForm({
           onChange={(e) => setPassword(e.target.value)}
         />
         {error && <p className="text-sm text-red-600">{error}</p>}
-        <Button type="submit" disabled={!password || submitting}>
-          {submitting ? "Checking..." : "View map"}
+        <Button
+          type="submit"
+          disabled={!password || submitting || verified || isRefreshing}
+        >
+          {submitting || verified || isRefreshing ? "Checking..." : "View map"}
         </Button>
       </form>
     </div>

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,5 +1,6 @@
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 import ReadOnlyMapControls from "@/app/(private)/map/[id]/components/readonly/ReadOnlyMapControls";
 import ReadOnlyNavbar from "@/app/(private)/map/[id]/components/readonly/ReadOnlyNavbar";
 import SharedMap from "@/app/(private)/map/[id]/components/SharedMap";
@@ -18,12 +19,17 @@ interface Props {
   searchParams: Promise<{ viewId?: string }>;
 }
 
+// Deduplicate the lookups between generateMetadata and the page render
+// (memoised per request, and only within this module)
+const getShareByToken = cache(findMapShareByToken);
+const getMapById = cache(findMapById);
+
 export async function generateMetadata({
   params,
 }: Pick<Props, "params">): Promise<Metadata> {
   const { token } = await params;
-  const share = await findMapShareByToken(token);
-  const map = share?.enabled ? await findMapById(share.mapId) : null;
+  const share = await getShareByToken(token);
+  const map = share?.enabled ? await getMapById(share.mapId) : null;
   return {
     title: map ? `${map.name} - Mapped` : "Mapped",
     // Share links are unlisted: never index them
@@ -35,7 +41,7 @@ export default async function SharedMapPage({ params, searchParams }: Props) {
   const { token } = await params;
   const { viewId: requestedViewId } = await searchParams;
 
-  const share = await findMapShareByToken(token);
+  const share = await getShareByToken(token);
   if (!share || !share.enabled) {
     notFound();
   }
@@ -45,7 +51,7 @@ export default async function SharedMapPage({ params, searchParams }: Props) {
 
   if (!grant) {
     if (share.passwordHash) {
-      const map = await findMapById(share.mapId);
+      const map = await getMapById(share.mapId);
       return (
         <SharePasswordForm token={token} mapName={map?.name ?? "Shared map"} />
       );

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,5 +1,5 @@
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import ReadOnlyMapControls from "@/app/(private)/map/[id]/components/readonly/ReadOnlyMapControls";
 import ReadOnlyNavbar from "@/app/(private)/map/[id]/components/readonly/ReadOnlyNavbar";
 import SharedMap from "@/app/(private)/map/[id]/components/SharedMap";
@@ -9,12 +9,13 @@ import { findMapById } from "@/server/repositories/Map";
 import { findMapShareByToken } from "@/server/repositories/MapShare";
 import { findValidShareGrantForMap } from "@/server/utils/auth";
 import { createCaller, getQueryClient, trpc } from "@/services/trpc/server";
+import ShareClaim from "./components/ShareClaim";
 import SharePasswordForm from "./components/SharePasswordForm";
 import type { Metadata } from "next";
 
 interface Props {
   params: Promise<{ token: string }>;
-  searchParams: Promise<{ viewId?: string; c?: string }>;
+  searchParams: Promise<{ viewId?: string }>;
 }
 
 export async function generateMetadata({
@@ -32,7 +33,7 @@ export async function generateMetadata({
 
 export default async function SharedMapPage({ params, searchParams }: Props) {
   const { token } = await params;
-  const { viewId: requestedViewId, c: claimed } = await searchParams;
+  const { viewId: requestedViewId } = await searchParams;
 
   const share = await findMapShareByToken(token);
   if (!share || !share.enabled) {
@@ -49,17 +50,10 @@ export default async function SharedMapPage({ params, searchParams }: Props) {
         <SharePasswordForm token={token} mapName={map?.name ?? "Shared map"} />
       );
     }
-    // Passwordless: the grant cookie is minted by a route handler (cookies
-    // cannot be set during page render) which redirects back here. `c=1`
-    // marks a completed claim, so blocked cookies show a message instead
-    // of looping.
-    if (claimed) {
-      return <CookiesRequiredMessage />;
-    }
-    const claimPath = requestedViewId
-      ? `/api/share/${token}/claim?viewId=${encodeURIComponent(requestedViewId)}`
-      : `/api/share/${token}/claim`;
-    redirect(claimPath);
+    // Passwordless: the grant cookie is minted by the claim endpoint
+    // (cookies cannot be set during page render). ShareClaim calls it and
+    // refreshes, after which the grant check above passes.
+    return <ShareClaim token={token} />;
   }
 
   const caller = await createCaller();
@@ -96,16 +90,5 @@ export default async function SharedMapPage({ params, searchParams }: Props) {
         </div>
       </MapJotaiProvider>
     </HydrationBoundary>
-  );
-}
-
-function CookiesRequiredMessage() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center p-8 text-center">
-      <p className="max-w-[40ch] text-base">
-        This shared map needs cookies to work. Please enable cookies for this
-        site and reload the page.
-      </p>
-    </div>
   );
 }

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,0 +1,111 @@
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { notFound, redirect } from "next/navigation";
+import ReadOnlyMapControls from "@/app/(private)/map/[id]/components/readonly/ReadOnlyMapControls";
+import ReadOnlyNavbar from "@/app/(private)/map/[id]/components/readonly/ReadOnlyNavbar";
+import SharedMap from "@/app/(private)/map/[id]/components/SharedMap";
+import MapJotaiProvider from "@/app/(private)/map/[id]/providers/MapJotaiProvider";
+import { getShareGrants } from "@/auth/shareGrants";
+import { findMapById } from "@/server/repositories/Map";
+import { findMapShareByToken } from "@/server/repositories/MapShare";
+import { findValidShareGrantForMap } from "@/server/utils/auth";
+import { createCaller, getQueryClient, trpc } from "@/services/trpc/server";
+import SharePasswordForm from "./components/SharePasswordForm";
+import type { Metadata } from "next";
+
+interface Props {
+  params: Promise<{ token: string }>;
+  searchParams: Promise<{ viewId?: string; c?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: Pick<Props, "params">): Promise<Metadata> {
+  const { token } = await params;
+  const share = await findMapShareByToken(token);
+  const map = share?.enabled ? await findMapById(share.mapId) : null;
+  return {
+    title: map ? `${map.name} - Mapped` : "Mapped",
+    // Share links are unlisted: never index them
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function SharedMapPage({ params, searchParams }: Props) {
+  const { token } = await params;
+  const { viewId: requestedViewId, c: claimed } = await searchParams;
+
+  const share = await findMapShareByToken(token);
+  if (!share || !share.enabled) {
+    notFound();
+  }
+
+  const grants = await getShareGrants();
+  const grant = await findValidShareGrantForMap(grants, share.mapId);
+
+  if (!grant) {
+    if (share.passwordHash) {
+      const map = await findMapById(share.mapId);
+      return (
+        <SharePasswordForm token={token} mapName={map?.name ?? "Shared map"} />
+      );
+    }
+    // Passwordless: the grant cookie is minted by a route handler (cookies
+    // cannot be set during page render) which redirects back here. `c=1`
+    // marks a completed claim, so blocked cookies show a message instead
+    // of looping.
+    if (claimed) {
+      return <CookiesRequiredMessage />;
+    }
+    const claimPath = requestedViewId
+      ? `/api/share/${token}/claim?viewId=${encodeURIComponent(requestedViewId)}`
+      : `/api/share/${token}/claim`;
+    redirect(claimPath);
+  }
+
+  const caller = await createCaller();
+  const map = await caller.map.byId({ mapId: share.mapId });
+  const views = [...map.views].sort((a, b) => a.position - b.position);
+  const viewId =
+    views.find((v) => v.id === requestedViewId)?.id ?? views[0]?.id;
+
+  // Seed the React Query cache so the client's `useMapQuery` picks the map
+  // up without a separate fetch (same pattern as the public map page)
+  const queryClient = getQueryClient();
+  queryClient.setQueryData(trpc.map.byId.queryKey({ mapId: share.mapId }), map);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <MapJotaiProvider mapId={share.mapId} viewId={viewId} isReadOnlyRoute>
+        <div className="relative h-screen w-full">
+          <SharedMap />
+          <div className="absolute inset-0 z-10 pointer-events-none flex flex-col">
+            <ReadOnlyNavbar />
+            <div className="flex-1 min-h-0 relative">
+              {/* Desktop-only message for small screens */}
+              <div className="pointer-events-auto lg:hidden flex h-full w-full justify-center items-center p-8 text-center z-20 relative bg-white">
+                <p className="max-w-[40ch] font-medium text-base">
+                  Your screen is too small to view this map. Please use a device
+                  with a larger screen.
+                </p>
+              </div>
+              <div className="hidden lg:contents">
+                <ReadOnlyMapControls />
+              </div>
+            </div>
+          </div>
+        </div>
+      </MapJotaiProvider>
+    </HydrationBoundary>
+  );
+}
+
+function CookiesRequiredMessage() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center p-8 text-center">
+      <p className="max-w-[40ch] text-base">
+        This shared map needs cookies to work. Please enable cookies for this
+        site and reload the page.
+      </p>
+    </div>
+  );
+}

--- a/src/hooks/useDataSources.ts
+++ b/src/hooks/useDataSources.ts
@@ -3,7 +3,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 import { useCallback, useMemo } from "react";
-import { isPublicMapRouteAtom } from "@/app/(private)/map/[id]/atoms/mapStateAtoms";
+import {
+  isPublicMapRouteAtom,
+  isReadOnlyRouteAtom,
+} from "@/app/(private)/map/[id]/atoms/mapStateAtoms";
 import { useMapConfig } from "@/app/(private)/map/[id]/hooks/useMapConfig";
 import { useMapId } from "@/app/(private)/map/[id]/hooks/useMapCore";
 import {
@@ -18,11 +21,17 @@ export function useDataSources() {
   const trpc = useTRPC();
   const organisationId = useOrganisationId();
   const isPublicMapRoute = useAtomValue(isPublicMapRouteAtom);
+  const isReadOnlyRoute = useAtomValue(isReadOnlyRouteAtom);
   const isSuperadminDataSourceRoute = useAtomValue(
     isSuperadminDataSourceRouteAtom,
   );
   const mapId = useMapId();
   const viewId = useViewId();
+
+  // Routes serving anonymous viewers (the public map page and the
+  // read-only shared map page) list only the data sources the map/view
+  // visualises; `listReadable` requires an authenticated user.
+  const isAnonymousViewerRoute = isPublicMapRoute || isReadOnlyRoute;
 
   const listPublicQuery = useQuery(
     trpc.dataSource.listPublic.queryOptions(undefined, {
@@ -35,20 +44,20 @@ export function useDataSources() {
       {
         activeOrganisationId: organisationId ?? undefined,
       },
-      { enabled: !isPublicMapRoute && !isSuperadminDataSourceRoute },
+      { enabled: !isAnonymousViewerRoute && !isSuperadminDataSourceRoute },
     ),
   );
 
   const listForMapViewQuery = useQuery(
     trpc.dataSource.listForMapView.queryOptions(
       { mapId: mapId ?? "", viewId: viewId ?? "" },
-      { enabled: isPublicMapRoute && Boolean(mapId) && Boolean(viewId) },
+      { enabled: isAnonymousViewerRoute && Boolean(mapId) && Boolean(viewId) },
     ),
   );
 
   const query = isSuperadminDataSourceRoute
     ? listPublicQuery
-    : isPublicMapRoute
+    : isAnonymousViewerRoute
       ? listForMapViewQuery
       : listReadableQuery;
 

--- a/src/server/services/ratelimit.ts
+++ b/src/server/services/ratelimit.ts
@@ -52,3 +52,13 @@ export async function checkForgotPasswordAttempt(ip: string): Promise<boolean> {
   const count = await recordAttempt(`rate_limit:forgot_password:${ip}`);
   return count <= FORGOT_PASSWORD_MAX_ATTEMPTS;
 }
+
+const SHARE_PASSWORD_MAX_ATTEMPTS = 5;
+
+export async function checkSharePasswordAttempt(
+  ip: string,
+  token: string,
+): Promise<boolean> {
+  const count = await recordAttempt(`rate_limit:share_password:${token}:${ip}`);
+  return count <= SHARE_PASSWORD_MAX_ATTEMPTS;
+}


### PR DESCRIPTION
## Summary

The frontend for **read-only private map sharing** — stages 4–5 of the plan in `READ_ONLY_PRIVATE_MAPS.md`, building on the backend merged in #468. Adds the `/share/[token]` viewer route and the password gate. (Stage 6 — the share dialog, feature flag, and toggle rename — follows in a final PR; until it lands, shares can only be created via the `mapShare` tRPC router.)

## The viewer (`/share/[token]`)

A chrome-free version of the private map view for anonymous recipients:

- **Server component** resolves the token → `notFound()` if missing/disabled → checks the grant cookie → renders the map shell, the password form, or redirects through the claim endpoint. The map is fetched server-side (the grant cookie authorises the tRPC caller) and seeded into the React Query cache, same pattern as the public map page. `robots: noindex` on the route.
- **What recipients see**: boundary hover info and the inspector (top), display-only choropleth legend + marker legend + map style selector (bottom-left), zoom (bottom-right), timeline (bottom-centre), and a slim navbar with the map name, a view switcher, and area search. No control panels, no table, no draw/pin modes.
- **View switching** works across all the map's views (client-side, URL kept shareable via `?viewId=`), matching the whole-map share scope.

## Grant minting (who sets the cookie, and when)

- **Passwordless**: the page renders `ShareClaim`, which POSTs to `/api/share/[token]/claim` (mints the grant cookie, returns 204 — exists because Next.js can't set cookies during page render) and then refreshes, after which the server component sees the grant — the same mechanism as the password flow, minus the form. The URL never changes. Blocked cookies are detected without URL state (a sessionStorage timestamp catches remount loops; a finished refresh still rendering `ShareClaim` means the cookie didn't stick) and show a friendly message instead of looping.
- **Password-protected**: the page renders `SharePasswordForm`; `POST /api/share/[token]/verify` checks scrypt, rate-limited **5 attempts / 15 min per IP + token** via the existing Redis limiter, and mints on success. The form then refreshes, and the server component sees the grant.

## Keeping read-only actually read-only

The private map tree assumes an editing user in several places; each is handled:

- `ReadOnlyNavbar` exists because the private navbar **writes on mount** (auto thumbnail upload, initial-view creation) — neither is mounted.
- `useMapViews` now skips `map.updateViews`/`mapView.delete` on the read-only route: map-style and timeline changes still update the query cache (instant feedback) but are never persisted and reset on reload.
- The inspector hides its config gears, "Add to areas", and "View in table" via a new `useMapEditable()` hook (backed by `isReadOnlyRouteAtom`, following the `isPublicMapRouteAtom` precedent). The Notes tab already self-gates on org membership.
- `useDataSources` uses `dataSource.listForMapView` (grant-authorised) instead of the `protectedProcedure` `listReadable` on anonymous viewer routes.
- `LegendDisplay` is a new display-only choropleth legend (bars + labels, reusing `LegendBars`/`BivariateLegend`); the 790-line editor `Legend` is untouched. `MarkerLegend` was already write-free and is reused as-is.
- The markers streaming API now honours the marker-styling `properties` param for grant holders whose share covers the data source — so shared maps look exactly like the editor, while public-map/public-data-source anonymous requests stay on minimal properties.

## Test plan

- [x] All 40 existing share tests still pass (repository, router, access control — including the password-change invalidation lifecycle that drives the mid-session re-prompt)
- [x] `npm run lint` clean (prettier, eslint, tsc, madge)
- [x] **Manual (stage 4 checkpoint)**: enable a passwordless share via `mapShare.enable`, open the link logged out — map renders read-only with legend/hover/inspector/zoom/style/timeline/search; view switching works; no write requests in the network tab
- [x] **Manual (stage 5 checkpoint)**: set a password, open in incognito — form shows, wrong password rejected and rate-limited, correct password shows the map; changing the password boots an open session back to the form on next load

## Notes for reviewers

- The claim/verify route handlers are deliberately untested at the unit level (they're thin wrappers over `cookies()` + already-tested primitives); the manual checkpoints above cover them.
- A viewer whose grant goes stale mid-session (password changed) sees data requests start failing until their next page load, which re-prompts. A proactive client-side bounce on 401 is a possible polish item, noted in the plan.
- Share viewers are desktop-only for now (same small-screen message as the private editor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

